### PR TITLE
 Rework autotrade algorithm

### DIFF
--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -602,8 +602,10 @@ function tradeZebras() {
 		// Determine how much existing iron must be converted to steel to make room (up to a limit of 'all of it')
 		var ironOverflow = Math.min((ironResource.value + expectedIron) - targetIron, ironResource.value);
 
-		// Craft the necessary quantity of plates, with each crafting consuming 125 units of iron
-		gamePage.craft("plate", ironOverflow / 125);
+		// Craft the necessary quantity of plates, if any, with each crafting consuming 125 units of iron
+		if (ironOverflow > 0) {
+			gamePage.craft("plate", ironOverflow / 125);
+		}
 	}
 
 

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -564,7 +564,7 @@ function autoTrade() {
 		// Calculate the number of trades necessary to get the required uranium:
 		// First, calculate the amount returned by each trade if it manages to return any
 		// For uranium, this is 1 unit per trade boosted by your trade ratio, with no seasonal variations; the random variation is irrelevant since it cancels out
-		var expectedUraniumPerTrade = 1 * gamePage.diplomacy.getTradeRatio();
+		var expectedUraniumPerTrade = 1 * (1 + gamePage.diplomacy.getTradeRatio());
 		
 		// The Dragons are neutral, so trades never fail entirely
 

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -748,9 +748,9 @@ function emergencyTradeFood() {
 		return;
 	}
 
-	// We only want to trade for food if our catnip reserves are dangerously low, defined as being within 5 ticks of starvation
+	// We only want to trade for food if our catnip reserves are dangerously low, defined as either being under 2% full or within 5 ticks of starvation
 	var catnipPerTick = gamePage.getResourcePerTick('catnip');
-	if (catnipResource.value > catnipPerTick * -5) {
+	if (catnipResource.value > Math.max(catnipResource.maxValue * 0.02, catnipPerTick * -5)) {
 		return;
 	}
 

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -194,6 +194,7 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '</div>' +
 '</div>';
 
+
 $("#footerLinks").append(htmlMenuAddition);
 
 var bldSelectAddition = '<div id="buildingSelect" style="display:none; margin-top:-500px; width:200px" class="dialog help">' +
@@ -248,6 +249,7 @@ var bldSelectAddition = '<div id="buildingSelect" style="display:none; margin-to
 
 '</div>';
 
+
 var spaceSelectAddition = '<div id="spaceSelect" style="display:none; margin-top:-400px; width:200px" class="dialog help">' +
 '<a href="#" onclick="$(\'#spaceSelect\').hide(); $(\'#buildingSelect\').toggle();" style="position: absolute; top: 10px; left: 15px;">cath</a>' +
 '<a href="#" onclick="$(\'#spaceSelect\').hide();" style="position: absolute; top: 10px; right: 15px;">close</a>' +
@@ -300,6 +302,7 @@ var spaceSelectAddition = '<div id="spaceSelect" style="display:none; margin-top
 '	<input type="checkbox" id="tecSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'48\', \'tecSBld\');"><label for="tecSBld">Tectonic</label><br /><br />' +
 
 '</div>';
+
 
 function verifyBuildingSelected(buildingNumber, buildingCheckID) {
 	var bldIsChecked = document.getElementById(buildingCheckID).checked;
@@ -962,7 +965,7 @@ function autoParty() {
 		var culture = gamePage.resPool.get('culture').value;
 		var parchment = gamePage.resPool.get('parchment').value;
 
-		if (catpower > 1500 && culture > 5000 && parchment > 2500) {
+		if ((catpower > 1500) && (culture > 5000) && (parchment > 2500) && (gamePage.calendar.festivalDays < 4000)) {
 			if (gamePage.prestige.getPerk("carnivals").researched)
 				gamePage.village.holdFestival(1);
 			else if (gamePage.calendar.festivalDays = 0) {

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -498,7 +498,6 @@ function autoTrade() {
 	// Therefore, to maximize the number of trades we get per visit, we only want to trade if the duration is already under that cap or if our unobtainium stockpile is full
 	if (
 			leviathansRace.unlocked
-			&& (leviathansRace.duration > 0)
 			&& (gamePage.diplomacy.getMaxTradeAmt(leviathansRace) > 0)
 			&& ((leviathansRace.duration <= 400 + (100 * leviathansRace.energy)) || (unobtainiumResource.value + (gamePage.getResourcePerTick('unobtainium', true) * 26) > unobtainiumResource.maxValue))
 	) {

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -2,7 +2,7 @@
 var autoCheck = ['false', 'false', 'false', 'false', 'false', 'false', 'false', 'false', 'false', 'false'];
 var autoName = ['build', 'craft', 'hunt', 'trade', 'praise', 'science', 'upgrade', 'party', 'assign', 'energy'];
 
-var tradeMax = {uranium: false, coal: false};
+var tradeMax = {uranium: false, coal: false, iron: false};
 
 // These will allow quick selection of the buildings which consume energy
 var bldSmelter = gamePage.bld.buildingsData[15];
@@ -186,6 +186,7 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '<button id="autoTrade" style="color:red" onclick="autoSwitch(autoCheck[3], 3, autoName[3], \'autoTrade\')"> Auto Trade </button><br />' +
 '<input id= "tradeMaxUranium" type="checkbox" onclick="tradeMax.uranium = this.checked" /><label for="tradeMaxUranium">Maximize uranium trades</label><br />' +
 '<input id= "tradeMaxCoal" type="checkbox" onclick="tradeMax.coal = this.checked" /><label for="tradeMaxCoal">Maximize coal trades</label><br />' +
+'<input id= "tradeMaxIron" type="checkbox" onclick="tradeMax.iron = this.checked" /><label for="tradeMaxIron">Maximize iron trades</label><br />' +
 '<button id="autoPraise" style="color:red" onclick="autoSwitch(autoCheck[4], 4, autoName[4], \'autoPraise\')"> Auto Praise </button><br /><br />' +
 '<button id="autoScience" style="color:red" onclick="autoSwitch(autoCheck[5], 5, autoName[5], \'autoScience\')"> Auto Science </button><br />' +
 '<button id="autoUpgrade" style="color:red" onclick="autoSwitch(autoCheck[6], 6, autoName[6], \'autoUpgrade\')"> Auto Upgrade </button><br />' +
@@ -507,6 +508,7 @@ function autoTrade() {
 	tradeZebras();
 	tradeDragons();
 	tradeSpiders();
+	tradeGriffins();
 }
 
 
@@ -788,6 +790,95 @@ function tradeSpiders() {
 
 	// Perform the trades
 	gamePage.diplomacy.tradeMultiple(spidersRace, tradesToPerform);
+}
+
+// Trade with the Griffins
+var griffinsRace = gamePage.diplomacy.get("griffins");
+function tradeGriffins() {
+	// Check that the Griffins are available to trade with
+	if (!griffinsRace.unlocked) {
+		return;
+	}
+
+	// Check that our iron stockpile isn't already filled beyond its normal capacity
+	if (ironResource.value > (ironResource.maxValue + 1)) {
+		return;
+	}
+
+	// Determine how many trades are possible given our current resources, and check that this number is not 0
+	var maxTradesPossible = gamePage.diplomacy.getMaxTradeAmt(griffinsRace);
+	if ((maxTradesPossible === undefined) || (maxTradesPossible < 1)) {
+		return;
+	}
+
+
+	// Determine how much iron we can expect from each trade, on average:
+
+	// First, calculate the amount of the desired resource returned by each trade if it manages to return any
+	// For iron, this is 250 units per trade boosted by your trade ratio, modified by a seasonal modifier; there's a random variation, but it's irrelevant since it cancels itself out
+	var expectedIronPerTrade = 250 * (1 + gamePage.diplomacy.getTradeRatio()) * griffinsRace.sells[0].seasons[gamePage.calendar.getCurSeason().name];
+
+	// Then modify that by the effects of race relations
+	// For the Griffins, this is the chance any given trade will fail because they are hostile
+	var tradeChance = 85 + gamePage.getEffect("standingRatio") + (diplomacyPerk.researched ? 10 : 0);
+	if (tradeChance < 100) {
+		expectedIronPerTrade *= tradeChance / 100;
+	}
+
+	// Then modify that by the chance that a successful trade will not include the desired resource in its results
+	// For iron, this never happens
+
+
+	// Our target final iron level is the maximum capacity of our stockpile, minus a buffer of 5 ticks' production to ensure it doesn't overflow before the next autoCraft() (assuming our iron income is positive)
+	var targetIron = ironResource.maxValue - Math.max(gamePage.getResourcePerTick('iron', true) * 5, 0);
+
+
+	// Determine how many trades to perform depending on the current trade mode
+	if (tradeMax.iron) {
+		// We are in maximize mode, which means we want to trade for as much iron as possible, converting any excess into steel
+
+		// Determine the maximum amount of iron we can covert to steel right now
+		var maxIronCraftable = Math.min(ironResource.value, ironResource.value);
+
+		// Determine the maximum amount of space that we can make available in our iron stockpile right now
+		var maxIronSpace = targetIron - (ironResource.value - maxIronCraftable);
+
+		// Calculate the maximum number of trades we can make and fit the results into that space
+		var maxTradesFit = Math.floor(maxIronSpace / expectedIronPerTrade);
+
+		// If possible, we want to perform as many trades as we have the resources for; if we don't have enough space in the stockpile to do that, we just do as many as we can fit
+		var tradesToPerform = Math.min(maxTradesPossible, maxTradesFit);
+
+
+		// Convert the excess iron:
+		// Determine how much iron those trades will return
+		var expectedIron = tradesToPerform * expectedIronPerTrade;
+
+		// Determine how much existing iron must be converted to steel to make room (up to a limit of 'all of it')
+		var ironOverflow = Math.min((ironResource.value + expectedIron) - targetIron, ironResource.value);
+
+		// Craft the necessary quantity of steel, with each crafting consuming 100 units of iron
+		gamePage.craft("steel", ironOverflow / 100);
+	} else {
+		// We are in normal mode, which means we want to trade for just enough iron to fill our stockpile
+
+		// Determine the amount of iron needed to reach our target
+		var ironRequired = targetIron - ironResource.value;
+
+		// Determine how many trades are needed to get that much iron, rounded down
+		var tradesRequired = Math.floor(ironRequired / expectedIronPerTrade);
+
+		// If no trades are necessary, we're done
+		if (tradesRequired < 1) {
+			return;
+		}
+
+		// If possible, we want to perform as many trades as necessary to fill the stockpile; if we don't have enough resources to do that, we just do as many as we can
+		var tradesToPerform = Math.min(tradesRequired, maxTradesPossible);
+	}
+
+	// Perform the trades
+	gamePage.diplomacy.tradeMultiple(griffinsRace, tradesToPerform);
 }
 
 

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -485,6 +485,7 @@ function autoSpace() {
 // Trade automatically
 var leviathansRace = gamePage.diplomacy.get("leviathans");
 var goldResource = gamePage.resPool.get('gold');
+var unobtainiumResource = gamePage.resPool.get('unobtainium');
 var diplomacyPerk = gamePage.prestige.getPerk("diplomacy");
 function autoTrade() {
 	// If the auto-trade button is not selected, abort
@@ -492,11 +493,19 @@ function autoTrade() {
 		return;
 	}
 
-	// If it is possible to trade with the Leviathan, we always want to do so
-	if (leviathansRace.unlocked && (leviathansRace.duration > 0) && (gamePage.diplomacy.getMaxTradeAmt(leviathansRace) > 0)) {
-		// If it is possible to trade with the Leviathans, we always wish to do so, and with the maximum amount possible
+
+	// Trading with the Leviathans causes their visit's remaining duration to be reduced to a cap
+	// Therefore, to maximize the number of trades we get per visit, we only want to trade if the duration is already under that cap or if our unobtainium stockpile is full
+	if (
+			leviathansRace.unlocked
+			&& (leviathansRace.duration > 0)
+			&& (gamePage.diplomacy.getMaxTradeAmt(leviathansRace) > 0)
+			&& ((leviathansRace.duration <= 400 + (100 * leviathansRace.energy)) || (unobtainiumResource.value + (gamePage.getResourcePerTick('unobtainium', true) * 26) > unobtainiumResource.maxValue))
+	) {
+		// When we do trade with the Leviathans, we always trade the maximum amount possible
 		gamePage.diplomacy.tradeAll(leviathansRace);
 	}
+
 
 	// Non-Leviathan trades are only performed if we are at or near our gold cap; since autoTrade is checked every 25 ticks, we abort if there's room at least 26 ticks of more gold production to avoid unnecessary waste
 	if ((goldResource.value + (gamePage.getResourcePerTick('gold', true) * 26)) < goldResource.maxValue) {

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -154,11 +154,11 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '<div id="optionSelect" style="display:none; margin-top:-600px; margin-left:-100px; width:200px" class="dialog help">' +
 '<a href="#" onclick="clearOptionHelpDiv();" style="position: absolute; top: 10px; right: 15px;">close</a>' +
 
-'<button id="killSwitch" onclick="clearInterval(clearScript()); gamePage.msg(deadScript);">Kill Switch</button> </br>' +
-'<button id="efficiencyButton" onclick="kittenEfficiency()">Check Efficiency</button></br></br>' +
+'<button id="killSwitch" onclick="clearInterval(clearScript()); gamePage.msg(deadScript);">Kill Switch</button> <br />' +
+'<button id="efficiencyButton" onclick="kittenEfficiency()">Check Efficiency</button><br /><br />' +
 
-'<button id="autoBuild" style="color:red" onclick="autoSwitch(autoCheck[0], 0, autoName[0], \'autoBuild\');"> Auto Build </button></br>' +
-'<button id="bldSelect" onclick="selectBuildings()">Select Building</button></br>' +
+'<button id="autoBuild" style="color:red" onclick="autoSwitch(autoCheck[0], 0, autoName[0], \'autoBuild\');"> Auto Build </button><br />' +
+'<button id="bldSelect" onclick="selectBuildings()">Select Building</button><br />' +
 
 '<button id="autoAssign" style="color:red" onclick="autoSwitch(autoCheck[8], 8, autoName[8], \'autoAssign\')"> Auto Assign </button>' +
 '<select id="autoAssignChoice" size="1" onclick="setAutoAssignValue()">' +
@@ -169,7 +169,7 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '<option value="miner">Miner</option>' +
 '<option value="hunter">Hunter</option>' +
 '<option value="engineer">Engineer</option>' +
-'</select></br>' +
+'</select><br />' +
 
 '<button id="autoCraft" style="color:red" onclick="autoSwitch(autoCheck[1], 1, autoName[1], \'autoCraft\')"> Auto Craft </button>' +
 '<select id="craftFur" size="1" onclick="setFurValue()">' +
@@ -177,20 +177,20 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '<option value="2">Manuscript</option>' +
 '<option value="3">Compendium</option>' +
 '<option value="4">Blueprint</option>' +
-'</select></br></br>' +
+'</select><br /><br />' +
 
 '<label id="secResLabel"> Secondary Craft % </label>' +
-'<span id="secResSpan" title="Between 0 and 100"><input id="secResText" type="text" style="width:25px" onchange="secResRatio = this.value" value="30"></span></br></br>' +
+'<span id="secResSpan" title="Between 0 and 100"><input id="secResText" type="text" style="width:25px" onchange="secResRatio = this.value" value="30"></span><br /><br />' +
 
-'<button id="autoHunt" style="color:red" onclick="autoSwitch(autoCheck[2], 2, autoName[2], \'autoHunt\')"> Auto Hunt </button></br>' +
-'<button id="autoTrade" style="color:red" onclick="autoSwitch(autoCheck[3], 3, autoName[3], \'autoTrade\')"> Auto Trade </button></br>' +
-'<input id= "tradeMaxUranium" type="checkbox" onclick="tradeMax.uranium = this.checked" /><label for="tradeMaxUranium">Maximize uranium trades</label></br>' +
-'<input id= "tradeMaxCoal" type="checkbox" onclick="tradeMax.coal = this.checked" /><label for="tradeMaxCoal">Maximize coal trades</label></br>' +
-'<button id="autoPraise" style="color:red" onclick="autoSwitch(autoCheck[4], 4, autoName[4], \'autoPraise\')"> Auto Praise </button></br></br>' +
-'<button id="autoScience" style="color:red" onclick="autoSwitch(autoCheck[5], 5, autoName[5], \'autoScience\')"> Auto Science </button></br>' +
-'<button id="autoUpgrade" style="color:red" onclick="autoSwitch(autoCheck[6], 6, autoName[6], \'autoUpgrade\')"> Auto Upgrade </button></br>' +
-'<button id="autoEnergy" style="color:red" onclick="autoSwitch(autoCheck[9], 9, autoName[9], \'autoEnergy\')"> Energy Control </button></br>' +
-'<button id="autoParty" style="color:red" onclick="autoSwitch(autoCheck[7], 7, autoName[7], \'autoParty\')"> Auto Party </button></br></br>' +
+'<button id="autoHunt" style="color:red" onclick="autoSwitch(autoCheck[2], 2, autoName[2], \'autoHunt\')"> Auto Hunt </button><br />' +
+'<button id="autoTrade" style="color:red" onclick="autoSwitch(autoCheck[3], 3, autoName[3], \'autoTrade\')"> Auto Trade </button><br />' +
+'<input id= "tradeMaxUranium" type="checkbox" onclick="tradeMax.uranium = this.checked" /><label for="tradeMaxUranium">Maximize uranium trades</label><br />' +
+'<input id= "tradeMaxCoal" type="checkbox" onclick="tradeMax.coal = this.checked" /><label for="tradeMaxCoal">Maximize coal trades</label><br />' +
+'<button id="autoPraise" style="color:red" onclick="autoSwitch(autoCheck[4], 4, autoName[4], \'autoPraise\')"> Auto Praise </button><br /><br />' +
+'<button id="autoScience" style="color:red" onclick="autoSwitch(autoCheck[5], 5, autoName[5], \'autoScience\')"> Auto Science </button><br />' +
+'<button id="autoUpgrade" style="color:red" onclick="autoSwitch(autoCheck[6], 6, autoName[6], \'autoUpgrade\')"> Auto Upgrade </button><br />' +
+'<button id="autoEnergy" style="color:red" onclick="autoSwitch(autoCheck[9], 9, autoName[9], \'autoEnergy\')"> Energy Control </button><br />' +
+'<button id="autoParty" style="color:red" onclick="autoSwitch(autoCheck[7], 7, autoName[7], \'autoParty\')"> Auto Party </button><br /><br />' +
 '</div>' +
 '</div>';
 
@@ -200,51 +200,51 @@ var bldSelectAddition = '<div id="buildingSelect" style="display:none; margin-to
 '<a href="#" onclick="$(\'#spaceSelect\').toggle(); $(\'#buildingSelect\').hide();" style="position: absolute; top: 10px; left: 15px;">space</a>' +
 '<a href="#" onclick="$(\'#buildingSelect\').hide();" style="position: absolute; top: 10px; right: 15px;">close</a>' +
 
-'	<br><input type="checkbox" id="hutChecker"><label for="hutChecker" onclick="$(\'.hutCheck\').click();"><b>Kitten Housing</b></label><br>' +
-'	<input type="checkbox" id="hutBld" class="hutCheck" onchange="verifyBuildingSelected(\'0\', \'hutBld\');"><label for="hutBld">Hut</label><br>' +
-'	<input type="checkbox" id="houseBld" class="hutCheck" onchange="verifyBuildingSelected(\'1\', \'houseBld\')"><label for="houseBld">Log House</label><br>' +
-'	<input type="checkbox" id="mansionBld" class="hutCheck" onchange="verifyBuildingSelected(\'2\', \'mansionBld\')"><label for="mansionBld">Mansion</label><br><br>' +
+'	<br /><input type="checkbox" id="hutChecker"><label for="hutChecker" onclick="$(\'.hutCheck\').click();"><b>Kitten Housing</b></label><br />' +
+'	<input type="checkbox" id="hutBld" class="hutCheck" onchange="verifyBuildingSelected(\'0\', \'hutBld\');"><label for="hutBld">Hut</label><br />' +
+'	<input type="checkbox" id="houseBld" class="hutCheck" onchange="verifyBuildingSelected(\'1\', \'houseBld\')"><label for="houseBld">Log House</label><br />' +
+'	<input type="checkbox" id="mansionBld" class="hutCheck" onchange="verifyBuildingSelected(\'2\', \'mansionBld\')"><label for="mansionBld">Mansion</label><br /><br />' +
 
-'	<input type="checkbox" id="craftChecker"><label for="craftChecker" onclick="$(\'.craftCheck\').click();"><b>Craft Bonuses</b></label><br>' +
-'	<input type="checkbox" id="workshopBld" class="craftCheck" onchange="verifyBuildingSelected(\'3\', \'workshopBld\')"><label for="workshopBld">Workshop</label><br>' +
-'	<input type="checkbox" id="factoryBld" class="craftCheck" onchange="verifyBuildingSelected(\'4\', \'factoryBld\')"><label for="factoryBld">Factory</label><br><br>' +
+'	<input type="checkbox" id="craftChecker"><label for="craftChecker" onclick="$(\'.craftCheck\').click();"><b>Craft Bonuses</b></label><br />' +
+'	<input type="checkbox" id="workshopBld" class="craftCheck" onchange="verifyBuildingSelected(\'3\', \'workshopBld\')"><label for="workshopBld">Workshop</label><br />' +
+'	<input type="checkbox" id="factoryBld" class="craftCheck" onchange="verifyBuildingSelected(\'4\', \'factoryBld\')"><label for="factoryBld">Factory</label><br /><br />' +
 
-'	<input type="checkbox" id="prodChecker"><label for="prodChecker" onclick="$(\'.prodCheck\').click();"><b>Production</b></label><br>' +
-'	<input type="checkbox" id="fieldBld" class="prodCheck" onchange="verifyBuildingSelected(\'5\', \'fieldBld\')"><label for="fieldBld">Catnip Field</label><br>' +
-'	<input type="checkbox" id="pastureBld" class="prodCheck" onchange="verifyBuildingSelected(\'6\', \'pastureBld\')"><label for="pastureBld">Pasture/Solar</label><br>' +
-'	<input type="checkbox" id="mineBld" class="prodCheck" onchange="verifyBuildingSelected(\'7\', \'mineBld\')"><label for="mineBld">Mine</label><br>' +
-'	<input type="checkbox" id="lumberBld" class="prodCheck" onchange="verifyBuildingSelected(\'8\', \'lumberBld\')"><label for="lumberBld">Lumber Mill</label><br>' +
-'	<input type="checkbox" id="aqueductBld" class="prodCheck" onchange="verifyBuildingSelected(\'9\', \'aqueductBld\')"><label for="aqueductBld">Aqueduct/Hydro</label><br>' +
-'	<input type="checkbox" id="oilBld" class="prodCheck" onchange="verifyBuildingSelected(\'10\', \'oilBld\')"><label for="oilBld">Oil Well</label><br>' +
-'	<input type="checkbox" id="quarryBld" class="prodCheck" onchange="verifyBuildingSelected(\'11\', \'quarryBld\')"><label for="quarryBld">Quarry</label><br><br>' +
+'	<input type="checkbox" id="prodChecker"><label for="prodChecker" onclick="$(\'.prodCheck\').click();"><b>Production</b></label><br />' +
+'	<input type="checkbox" id="fieldBld" class="prodCheck" onchange="verifyBuildingSelected(\'5\', \'fieldBld\')"><label for="fieldBld">Catnip Field</label><br />' +
+'	<input type="checkbox" id="pastureBld" class="prodCheck" onchange="verifyBuildingSelected(\'6\', \'pastureBld\')"><label for="pastureBld">Pasture/Solar</label><br />' +
+'	<input type="checkbox" id="mineBld" class="prodCheck" onchange="verifyBuildingSelected(\'7\', \'mineBld\')"><label for="mineBld">Mine</label><br />' +
+'	<input type="checkbox" id="lumberBld" class="prodCheck" onchange="verifyBuildingSelected(\'8\', \'lumberBld\')"><label for="lumberBld">Lumber Mill</label><br />' +
+'	<input type="checkbox" id="aqueductBld" class="prodCheck" onchange="verifyBuildingSelected(\'9\', \'aqueductBld\')"><label for="aqueductBld">Aqueduct/Hydro</label><br />' +
+'	<input type="checkbox" id="oilBld" class="prodCheck" onchange="verifyBuildingSelected(\'10\', \'oilBld\')"><label for="oilBld">Oil Well</label><br />' +
+'	<input type="checkbox" id="quarryBld" class="prodCheck" onchange="verifyBuildingSelected(\'11\', \'quarryBld\')"><label for="quarryBld">Quarry</label><br /><br />' +
 
-'	<input type="checkbox" id="conversionChecker"><label for="conversionChecker" onclick="$(\'.convertCheck\').click();"><b>Conversion</b></label><br>' +
-'	<input type="checkbox" id="smelterBld" class="convertCheck" onchange="verifyBuildingSelected(\'12\', \'smelterBld\')"><label for="smelterBld">Smelter</label><br>' +
-'	<input type="checkbox" id="labBld" class="convertCheck" onchange="verifyBuildingSelected(\'13\', \'labBld\')"><label for="labBld">Bio Lab</label><br>' +
-'	<input type="checkbox" id="calcinerBld" class="convertCheck" onchange="verifyBuildingSelected(\'14\', \'calcinerBld\')"><label for="calcinerBld">Calciner</label><br>' +
-'	<input type="checkbox" id="reactorBld" class="convertCheck" onchange="verifyBuildingSelected(\'15\', \'reactorBld\')"><label for="reactorBld">Reactor</label><br>' +
-'	<input type="checkbox" id="acceleratorBld" class="convertCheck" onchange="verifyBuildingSelected(\'16\', \'acceleratorBld\')"><label for="acceleratorBld">Accelerator</label><br>' +
-'	<input type="checkbox" id="steamBld" class="convertCheck" onchange="verifyBuildingSelected(\'17\', \'steamBld\')"><label for="steamBld">Steamworks</label><br>' +
-'	<input type="checkbox" id="magnetoBld" class="convertCheck" onchange="verifyBuildingSelected(\'18\', \'magnetoBld\')"><label for="magnetoBld">Magneto</label><br><br>' +
+'	<input type="checkbox" id="conversionChecker"><label for="conversionChecker" onclick="$(\'.convertCheck\').click();"><b>Conversion</b></label><br />' +
+'	<input type="checkbox" id="smelterBld" class="convertCheck" onchange="verifyBuildingSelected(\'12\', \'smelterBld\')"><label for="smelterBld">Smelter</label><br />' +
+'	<input type="checkbox" id="labBld" class="convertCheck" onchange="verifyBuildingSelected(\'13\', \'labBld\')"><label for="labBld">Bio Lab</label><br />' +
+'	<input type="checkbox" id="calcinerBld" class="convertCheck" onchange="verifyBuildingSelected(\'14\', \'calcinerBld\')"><label for="calcinerBld">Calciner</label><br />' +
+'	<input type="checkbox" id="reactorBld" class="convertCheck" onchange="verifyBuildingSelected(\'15\', \'reactorBld\')"><label for="reactorBld">Reactor</label><br />' +
+'	<input type="checkbox" id="acceleratorBld" class="convertCheck" onchange="verifyBuildingSelected(\'16\', \'acceleratorBld\')"><label for="acceleratorBld">Accelerator</label><br />' +
+'	<input type="checkbox" id="steamBld" class="convertCheck" onchange="verifyBuildingSelected(\'17\', \'steamBld\')"><label for="steamBld">Steamworks</label><br />' +
+'	<input type="checkbox" id="magnetoBld" class="convertCheck" onchange="verifyBuildingSelected(\'18\', \'magnetoBld\')"><label for="magnetoBld">Magneto</label><br /><br />' +
 
-'	<input type="checkbox" id="scienceChecker"><label for="scienceChecker" onclick="$(\'.scienceCheck\').click();"><b>Science</b></label><br>' +
-'	<input type="checkbox" id="libraryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'19\', \'libraryBld\')"><label for="libraryBld">Library</label><br>' +
-'	<input type="checkbox" id="academyBld" class="scienceCheck" onchange="verifyBuildingSelected(\'20\', \'academyBld\')"><label for="academyBld">Academy</label><br>' +
-'	<input type="checkbox" id="obervatoryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'21\', \'obervatoryBld\')"><label for="obervatoryBld">Observatory</label><br><br>' +
+'	<input type="checkbox" id="scienceChecker"><label for="scienceChecker" onclick="$(\'.scienceCheck\').click();"><b>Science</b></label><br />' +
+'	<input type="checkbox" id="libraryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'19\', \'libraryBld\')"><label for="libraryBld">Library</label><br />' +
+'	<input type="checkbox" id="academyBld" class="scienceCheck" onchange="verifyBuildingSelected(\'20\', \'academyBld\')"><label for="academyBld">Academy</label><br />' +
+'	<input type="checkbox" id="obervatoryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'21\', \'obervatoryBld\')"><label for="obervatoryBld">Observatory</label><br /><br />' +
 
-'	<input type="checkbox" id="storageChecker"><label for="storageChecker" onclick="$(\'.storageCheck\').click();"><b>Storage</b></label><br>' +
-'	<input type="checkbox" id="barnBld" class="storageCheck" onchange="verifyBuildingSelected(\'22\', \'barnBld\')"><label for="barnBld">Barn</label><br>' +
-'	<input type="checkbox" id="harborBld" class="storageCheck" onchange="verifyBuildingSelected(\'23\', \'harborBld\')"><label for="harborBld">Harbor</label><br>' +
-'	<input type="checkbox" id="warehouseBld" class="storageCheck" onchange="verifyBuildingSelected(\'24\', \'warehouseBld\')"><label for="warehouseBld">Warehouse</label><br><br>' +
+'	<input type="checkbox" id="storageChecker"><label for="storageChecker" onclick="$(\'.storageCheck\').click();"><b>Storage</b></label><br />' +
+'	<input type="checkbox" id="barnBld" class="storageCheck" onchange="verifyBuildingSelected(\'22\', \'barnBld\')"><label for="barnBld">Barn</label><br />' +
+'	<input type="checkbox" id="harborBld" class="storageCheck" onchange="verifyBuildingSelected(\'23\', \'harborBld\')"><label for="harborBld">Harbor</label><br />' +
+'	<input type="checkbox" id="warehouseBld" class="storageCheck" onchange="verifyBuildingSelected(\'24\', \'warehouseBld\')"><label for="warehouseBld">Warehouse</label><br /><br />' +
 
-'	<input type="checkbox" id="otherChecker"><label for="otherChecker" onclick="$(\'.otherCheck\').click();"><b>Other</b></label><br>' +
-'	<input type="checkbox" id="ampBld" class="otherCheck" onchange="verifyBuildingSelected(\'25\', \'ampBld\')"><label for="ampBld">Amphitheatre/Broadcast</label><br>' +
-'	<input type="checkbox" id="tradeBld" class="otherCheck" onchange="verifyBuildingSelected(\'26\', \'tradeBld\')"><label for="tradeBld">Tradepost</label><br>' +
-'	<input type="checkbox" id="chapelBld" class="otherCheck" onchange="verifyBuildingSelected(\'27\', \'chapelBld\')"><label for="chapelBld">Chapel</label><br>' +
-'	<input type="checkbox" id="templeBld" class="otherCheck" onchange="verifyBuildingSelected(\'28\', \'templeBld\')"><label for="templeBld">Temple</label><br>' +
-'	<input type="checkbox" id="mintBld" class="otherCheck" onchange="verifyBuildingSelected(\'29\', \'mintBld\')"><label for="mintBld">Mint</label><br>' +
-'	<input type="checkbox" id="zigguratBld" class="otherCheck" onchange="verifyBuildingSelected(\'30\', \'zigguratBld\')"><label for="zigguratBld">Ziggurat</label><br>' +
-'	<input type="checkbox" id="unicBld" class="otherCheck" onchange="verifyBuildingSelected(\'31\', \'unicBld\')"><label for="unicBld">Unicorn Pasture</label><br></br>' +
+'	<input type="checkbox" id="otherChecker"><label for="otherChecker" onclick="$(\'.otherCheck\').click();"><b>Other</b></label><br />' +
+'	<input type="checkbox" id="ampBld" class="otherCheck" onchange="verifyBuildingSelected(\'25\', \'ampBld\')"><label for="ampBld">Amphitheatre/Broadcast</label><br />' +
+'	<input type="checkbox" id="tradeBld" class="otherCheck" onchange="verifyBuildingSelected(\'26\', \'tradeBld\')"><label for="tradeBld">Tradepost</label><br />' +
+'	<input type="checkbox" id="chapelBld" class="otherCheck" onchange="verifyBuildingSelected(\'27\', \'chapelBld\')"><label for="chapelBld">Chapel</label><br />' +
+'	<input type="checkbox" id="templeBld" class="otherCheck" onchange="verifyBuildingSelected(\'28\', \'templeBld\')"><label for="templeBld">Temple</label><br />' +
+'	<input type="checkbox" id="mintBld" class="otherCheck" onchange="verifyBuildingSelected(\'29\', \'mintBld\')"><label for="mintBld">Mint</label><br />' +
+'	<input type="checkbox" id="zigguratBld" class="otherCheck" onchange="verifyBuildingSelected(\'30\', \'zigguratBld\')"><label for="zigguratBld">Ziggurat</label><br />' +
+'	<input type="checkbox" id="unicBld" class="otherCheck" onchange="verifyBuildingSelected(\'31\', \'unicBld\')"><label for="unicBld">Unicorn Pasture</label><br /><br />' +
 
 '</div>';
 
@@ -252,52 +252,52 @@ var spaceSelectAddition = '<div id="spaceSelect" style="display:none; margin-top
 '<a href="#" onclick="$(\'#spaceSelect\').hide(); $(\'#buildingSelect\').toggle();" style="position: absolute; top: 10px; left: 15px;">cath</a>' +
 '<a href="#" onclick="$(\'#spaceSelect\').hide();" style="position: absolute; top: 10px; right: 15px;">close</a>' +
 
-'	</br></br><input type="checkbox" id="programs" class="programs" onchange="programBuild = this.checked; console.log(this.checked);"><label for="programs">Programs</label></br></br>' +
+'	<br /><br /><input type="checkbox" id="programs" class="programs" onchange="programBuild = this.checked; console.log(this.checked);"><label for="programs">Programs</label><br /><br />' +
 
-'	<input type="checkbox" id="spaceChecker"><label for="spaceChecker" onclick="$(\'.spaceCheck\').click();"><b>Space</b></label></br>' +
+'	<input type="checkbox" id="spaceChecker"><label for="spaceChecker" onclick="$(\'.spaceCheck\').click();"><b>Space</b></label><br />' +
 
-'	<input type="checkbox" id="elevSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'32\', \'elevSBld\');"><label for="elevSBld">Space Elevator</label></br>' +
-'	<input type="checkbox" id="satSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'33\', \'satSBld\');"><label for="satSBld">Satellite</label></br>' +
-'	<input type="checkbox" id="statSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'34\', \'statSBld\');"><label for="statSBld">Space Station</label></br></br>' +
+'	<input type="checkbox" id="elevSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'32\', \'elevSBld\');"><label for="elevSBld">Space Elevator</label><br />' +
+'	<input type="checkbox" id="satSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'33\', \'satSBld\');"><label for="satSBld">Satellite</label><br />' +
+'	<input type="checkbox" id="statSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'34\', \'statSBld\');"><label for="statSBld">Space Station</label><br /><br />' +
 
-'	<input type="checkbox" id="moonChecker"><label for="moonChecker" onclick="$(\'.moonCheck\').click();"><b>Moon</b></label></br>' +
+'	<input type="checkbox" id="moonChecker"><label for="moonChecker" onclick="$(\'.moonCheck\').click();"><b>Moon</b></label><br />' +
 
-'	<input type="checkbox" id="outSBld" class="moonCheck" onchange="verifyBuildingSelected(\'35\', \'outSBld\');"><label for="outSBld">Lunar Outpost</label></br>' +
-'	<input type="checkbox" id="baseSBld" class="moonCheck" onchange="verifyBuildingSelected(\'36\', \'baseSBld\');"><label for="baseSBld">Moon Base</label></br></br>' +
+'	<input type="checkbox" id="outSBld" class="moonCheck" onchange="verifyBuildingSelected(\'35\', \'outSBld\');"><label for="outSBld">Lunar Outpost</label><br />' +
+'	<input type="checkbox" id="baseSBld" class="moonCheck" onchange="verifyBuildingSelected(\'36\', \'baseSBld\');"><label for="baseSBld">Moon Base</label><br /><br />' +
 
-'	<input type="checkbox" id="duneChecker"><label for="duneChecker" onclick="$(\'.duneCheck\').click();"><b>Dune</b></label></br>' +
+'	<input type="checkbox" id="duneChecker"><label for="duneChecker" onclick="$(\'.duneCheck\').click();"><b>Dune</b></label><br />' +
 
 
-'	<input type="checkbox" id="crackSBld" class="duneCheck" onchange="verifyBuildingSelected(\'37\', \'crackSBld\');"><label for="crackSBld">Planet Cracker</label></br>' +
-'	<input type="checkbox" id="fracSBld" class="duneCheck" onchange="verifyBuildingSelected(\'38\', \'fracSBld\');"><label for="fracSBld">Hydro Fracturer</label></br>' +
-'	<input type="checkbox" id="spiceSBld" class="duneCheck" onchange="verifyBuildingSelected(\'39\', \'spiceSBld\');"><label for="spiceSBld">Spice Refinery</label></br></br>' +
+'	<input type="checkbox" id="crackSBld" class="duneCheck" onchange="verifyBuildingSelected(\'37\', \'crackSBld\');"><label for="crackSBld">Planet Cracker</label><br />' +
+'	<input type="checkbox" id="fracSBld" class="duneCheck" onchange="verifyBuildingSelected(\'38\', \'fracSBld\');"><label for="fracSBld">Hydro Fracturer</label><br />' +
+'	<input type="checkbox" id="spiceSBld" class="duneCheck" onchange="verifyBuildingSelected(\'39\', \'spiceSBld\');"><label for="spiceSBld">Spice Refinery</label><br /><br />' +
 
-'	<input type="checkbox" id="piscineChecker"><label for="piscineChecker" onclick="$(\'piscineCheck\').click();"><b>Piscine</b></label></br>' +
+'	<input type="checkbox" id="piscineChecker"><label for="piscineChecker" onclick="$(\'piscineCheck\').click();"><b>Piscine</b></label><br />' +
 
-'	<input type="checkbox" id="reVeSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'40\', \'reVeSBld\');"><label for="reVeSBld">Research Vessel</label></br>' +
-'	<input type="checkbox" id="orbSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'41\', \'orbSBld\');"><label for="orbSBld">Orbital Array</label></br></br>' +
+'	<input type="checkbox" id="reVeSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'40\', \'reVeSBld\');"><label for="reVeSBld">Research Vessel</label><br />' +
+'	<input type="checkbox" id="orbSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'41\', \'orbSBld\');"><label for="orbSBld">Orbital Array</label><br /><br />' +
 
-'	<input type="checkbox" id="heliosChecker"><label for="heliosChecker" onclick="$(\'.heliosCheck\').click();"><b>Helios</b></label></br>' +
+'	<input type="checkbox" id="heliosChecker"><label for="heliosChecker" onclick="$(\'.heliosCheck\').click();"><b>Helios</b></label><br />' +
 
-'	<input type="checkbox" id="sunSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'42\', \'sunSBld\');"><label for="sunSBld">Sunlifter</label></br>' +
-'	<input type="checkbox" id="contSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'43\', \'contSBld\');"><label for="contSBld">Containment Chamber</label></br></br>' +
+'	<input type="checkbox" id="sunSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'42\', \'sunSBld\');"><label for="sunSBld">Sunlifter</label><br />' +
+'	<input type="checkbox" id="contSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'43\', \'contSBld\');"><label for="contSBld">Containment Chamber</label><br /><br />' +
 
-'	<input type="checkbox" id="terminusChecker"><label for="terminusChecker" onclick="$(\'.terminusCheck\').click();"><b>Terminus</b></label></br>' +
+'	<input type="checkbox" id="terminusChecker"><label for="terminusChecker" onclick="$(\'.terminusCheck\').click();"><b>Terminus</b></label><br />' +
 
-'	<input type="checkbox" id="crySBld" class="terminusCheck" onchange="verifyBuildingSelected(\'44\', \'crySBld\');"><label for="crySBld">Cryostation</label></br></br>' +
+'	<input type="checkbox" id="crySBld" class="terminusCheck" onchange="verifyBuildingSelected(\'44\', \'crySBld\');"><label for="crySBld">Cryostation</label><br /><br />' +
 
-'	<input type="checkbox" id="kairoChecker"><label for="kairoChecker" onclick="$(\'.kairoCheck\').click();"><b>Kairo</b></label></br>' +
+'	<input type="checkbox" id="kairoChecker"><label for="kairoChecker" onclick="$(\'.kairoCheck\').click();"><b>Kairo</b></label><br />' +
 
-'	<input type="checkbox" id="beacSBld" class="kairoCheck" onchange="verifyBuildingSelected(\'45\', \'beacSBld\');"><label for="beacSBld">Space Beacon</label></br></br>' +
+'	<input type="checkbox" id="beacSBld" class="kairoCheck" onchange="verifyBuildingSelected(\'45\', \'beacSBld\');"><label for="beacSBld">Space Beacon</label><br /><br />' +
 
-'	<input type="checkbox" id="yarnChecker"><label for="yarnChecker" onclick="$(\'.yarnCheck\').click();"><b>Yarn</b></label></br>' +
+'	<input type="checkbox" id="yarnChecker"><label for="yarnChecker" onclick="$(\'.yarnCheck\').click();"><b>Yarn</b></label><br />' +
 
-'	<input type="checkbox" id="terrSBld" class="yarnCheck" onchange="verifyBuildingSelected(\'46\', \'terrSBld\');"><label for="terrSBld">Terraforming Station</label></br>' +
-'	<input type="checkbox" id="hydrSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'47\', \'hydrSBld\');"><label for="hydrSBld">Hydroponics</label></br></br>' +
+'	<input type="checkbox" id="terrSBld" class="yarnCheck" onchange="verifyBuildingSelected(\'46\', \'terrSBld\');"><label for="terrSBld">Terraforming Station</label><br />' +
+'	<input type="checkbox" id="hydrSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'47\', \'hydrSBld\');"><label for="hydrSBld">Hydroponics</label><br /><br />' +
 
-'	<input type="checkbox" id="centaurusChecker"><label for="centaurusChecker" onclick="$(\'.centaurusCheck\').click();"><b>Centaurus System</b></label></br>' +
+'	<input type="checkbox" id="centaurusChecker"><label for="centaurusChecker" onclick="$(\'.centaurusCheck\').click();"><b>Centaurus System</b></label><br />' +
 
-'	<input type="checkbox" id="tecSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'48\', \'tecSBld\');"><label for="tecSBld">Tectonic</label></br></br>' +
+'	<input type="checkbox" id="tecSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'48\', \'tecSBld\');"><label for="tecSBld">Tectonic</label><br /><br />' +
 
 '</div>';
 

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -501,7 +501,7 @@ function autoTrade() {
 	}
 
 	// Non-Leviathan trades are only performed if we are at or near our gold cap; since autoTrade is checked every 25 ticks, we abort if there's room at least 26 ticks of more gold production to avoid unnecessary waste
-	if ((goldResource.value + (gamePage.getResourcePerTick('gold') * 26)) < goldResource.maxValue) {
+	if ((goldResource.value + (gamePage.getResourcePerTick('gold', true) * 26)) < goldResource.maxValue) {
 		return;
 	}
 
@@ -557,7 +557,7 @@ function tradeZebras() {
 
 
 	// Our target final titanium level is the maximum capacity of our stockpile, minus a buffer of 5 ticks' production to ensure it doesn't overflow before the next autoCraft() (assuming our titanium income is positive)
-	var targetTitanium = titaniumResource.maxValue - Math.max(gamePage.getResourcePerTick('titanium') * 5, 0);
+	var targetTitanium = titaniumResource.maxValue - Math.max(gamePage.getResourcePerTick('titanium', true) * 5, 0);
 
 
 	// Determine how many trades to perform
@@ -593,7 +593,7 @@ function tradeZebras() {
 
 
 		// Our target final iron level is the maximum capacity of our stockpile, minus a buffer of 5 ticks' production to ensure it doesn't overflow before the next autoCraft() (assuming our iron income is positive)
-		var targetIron = ironResource.maxValue - Math.max(gamePage.getResourcePerTick('iron') * 5, 0);
+		var targetIron = ironResource.maxValue - Math.max(gamePage.getResourcePerTick('iron', true) * 5, 0);
 
 
 		// Determine how much iron those trades might return
@@ -658,7 +658,7 @@ function tradeDragons() {
 
 
 	// Our target final uranium level is the maximum capacity of our stockpile, minus a buffer of 5 ticks' production to ensure it doesn't overflow before the next autoCraft() (assuming our uranium income is positive)
-	var targetUranium = uraniumResource.maxValue - Math.max(gamePage.getResourcePerTick('uranium') * 5, 0);
+	var targetUranium = uraniumResource.maxValue - Math.max(gamePage.getResourcePerTick('uranium', true) * 5, 0);
 
 
 	// Determine how many trades to perform depending on the current trade mode
@@ -741,7 +741,7 @@ function tradeSpiders() {
 
 
 	// Our target final coal level is the maximum capacity of our stockpile, minus a buffer of 5 ticks' production to ensure it doesn't overflow before the next autoCraft() (assuming our coal income is positive)
-	var targetCoal = coalResource.maxValue - Math.max(gamePage.getResourcePerTick('coal') * 5, 0);
+	var targetCoal = coalResource.maxValue - Math.max(gamePage.getResourcePerTick('coal', true) * 5, 0);
 
 
 	// Determine how many trades to perform depending on the current trade mode
@@ -803,7 +803,7 @@ function emergencyTradeFood() {
 	}
 
 	// We only want to trade for food if our catnip reserves are dangerously low, defined as either being under 2% full or within 5 ticks of starvation
-	var catnipPerTick = gamePage.getResourcePerTick('catnip');
+	var catnipPerTick = gamePage.getResourcePerTick('catnip', true);
 	if (catnipResource.value > Math.max(catnipResource.maxValue * 0.02, catnipPerTick * -5)) {
 		return;
 	}
@@ -874,7 +874,7 @@ function autoCraft() {
 if (autoCheck[1] != "false") {
 for (var i = 0; i < resources.length; i++) {
     var curRes = gamePage.resPool.get(resources[i][0]);
-    var resourcePerTick = gamePage.getResourcePerTick(resources[i][0], 0);
+    var resourcePerTick = gamePage.getResourcePerTick(resources[i][0], true);
     var resourcePerCraft = (resourcePerTick * 3);
 		if (curRes.value > (curRes.maxValue - resourcePerCraft) && gamePage.workshop.getCraft(resources[i][1]).unlocked) {
 		gamePage.craft(resources[i][1], (resourcePerCraft / resources[i][2]));

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -11,8 +11,8 @@ var bldCalciner = gamePage.bld.buildingsData[16];
 var bldAccelerator = gamePage.bld.buildingsData[24];
 
  // These are the assorted variables
-var proVar = gamePage.resPool.energyProd; 
-var conVar = gamePage.resPool.energyCons;	
+var proVar = gamePage.resPool.energyProd;
+var conVar = gamePage.resPool.energyCons;
 var tickDownCounter = 1;
 var deadScript = "Script is dead";
 var furDerVal = 3;
@@ -24,35 +24,35 @@ var programBuild = false;
 
 
 var buildings = [
-		["Hut", false], 
-		["Log House", false], 
-		["Mansion", false], 
-		["Workshop", false], 
-		["Factory", false], 
-		["Catnip field", false], 
-		["Pasture", false], 
-		["Mine", false], 
-		["Lumber Mill", false], 
-		["Aqueduct", false], 
-		["Oil Well", false], 
-		["Quarry", false], 
-		["Smelter", false], 
-		["Bio Lab", false], 
-		["Calciner", false], 
-		["Reactor", false], 
-		["Accelerator", false], 
-		["Steamworks", false], 
-		["Magneto", false], 
-		["Library", false], 
-		["Academy", false], 
-		["Observatory", false], 
-		["Barn", false], 
-		["Harbour", false], 
-		["Warehouse", false], 
-		["Amphitheatre", false], 
-		["Tradepost", false], 
-		["Chapel", false], 
-		["Temple", false], 
+		["Hut", false],
+		["Log House", false],
+		["Mansion", false],
+		["Workshop", false],
+		["Factory", false],
+		["Catnip field", false],
+		["Pasture", false],
+		["Mine", false],
+		["Lumber Mill", false],
+		["Aqueduct", false],
+		["Oil Well", false],
+		["Quarry", false],
+		["Smelter", false],
+		["Bio Lab", false],
+		["Calciner", false],
+		["Reactor", false],
+		["Accelerator", false],
+		["Steamworks", false],
+		["Magneto", false],
+		["Library", false],
+		["Academy", false],
+		["Observatory", false],
+		["Barn", false],
+		["Harbour", false],
+		["Warehouse", false],
+		["Amphitheatre", false],
+		["Tradepost", false],
+		["Chapel", false],
+		["Temple", false],
 		["Mint", false],
 		["Ziggurat", false],
 		["Unicorn Pasture", false],
@@ -73,39 +73,39 @@ var buildings = [
 		["Terraforming Station", false, 7],
 		["Hydroponics", false, 7],
 		["Tectonic", false, 8]
-		];	
-		
+		];
+
 var buildingsList = [
-		["hut"], 
-		["logHouse"], 
-		["mansion"], 
-		["workshop"], 
-		["factory"], 
-		["field"], 
-		["pasture"], 
-		["mine"], 
-		["lumberMill"], 
-		["aqueduct"], 
-		["oilWell"], 
-		["quarry"], 
-		["smelter"], 
-		["biolab"], 
-		["calciner"], 
-		["reactor"], 
-		["accelerator"], 
-		["steamworks"], 
-		["magneto"], 
-		["library"], 
-		["academy"], 
-		["observatory"], 
-		["barn"], 
-		["harbor"], 
-		["warehouse"], 
-		["amphitheatre"], 
-		["tradepost"], 
-		["chapel"], 
-		["temple"], 
-		["mint"], 
+		["hut"],
+		["logHouse"],
+		["mansion"],
+		["workshop"],
+		["factory"],
+		["field"],
+		["pasture"],
+		["mine"],
+		["lumberMill"],
+		["aqueduct"],
+		["oilWell"],
+		["quarry"],
+		["smelter"],
+		["biolab"],
+		["calciner"],
+		["reactor"],
+		["accelerator"],
+		["steamworks"],
+		["magneto"],
+		["library"],
+		["academy"],
+		["observatory"],
+		["barn"],
+		["harbor"],
+		["warehouse"],
+		["amphitheatre"],
+		["tradepost"],
+		["chapel"],
+		["temple"],
+		["mint"],
 		["ziggurat"],
 		["unicornPasture"],
 		["spaceElevator"],
@@ -125,8 +125,8 @@ var buildingsList = [
 		["terraformingStation"],
 		["hydroponics"],
 		["tectonic"]
-		];	
-		
+		];
+
 var resources = [
        		["catnip", "wood", 50],
             ["wood", "beam", 175],
@@ -137,7 +137,7 @@ var resources = [
             ["uranium", "thorium", 250],
 			["unobtainium", "eludium", 1000]
                 ];
-				
+
 var secondaryResources = [
 			["beam", "scaffold", 50],
             ["steel", "alloy", 75],
@@ -147,14 +147,14 @@ var secondaryResources = [
 
 var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 
-'<a id="scriptOptions" onclick="selectOptions()"> | ScriptKitties </a>' + 
+'<a id="scriptOptions" onclick="selectOptions()"> | ScriptKitties </a>' +
 
-'<div id="optionSelect" style="display:none; margin-top:-400px; margin-left:-100px; width:200px" class="dialog help">' + 
-'<a href="#" onclick="clearOptionHelpDiv();" style="position: absolute; top: 10px; right: 15px;">close</a>' + 
+'<div id="optionSelect" style="display:none; margin-top:-400px; margin-left:-100px; width:200px" class="dialog help">' +
+'<a href="#" onclick="clearOptionHelpDiv();" style="position: absolute; top: 10px; right: 15px;">close</a>' +
 
 '<button id="killSwitch" onclick="clearInterval(clearScript()); gamePage.msg(deadScript);">Kill Switch</button> </br>' +
 '<button id="efficiencyButton" onclick="kittenEfficiency()">Check Efficiency</button></br></br>' +
-'<button id="autoBuild" style="color:red" onclick="autoSwitch(autoCheck[0], 0, autoName[0], \'autoBuild\');"> Auto Build </button></br>' + 
+'<button id="autoBuild" style="color:red" onclick="autoSwitch(autoCheck[0], 0, autoName[0], \'autoBuild\');"> Auto Build </button></br>' +
 '<button id="bldSelect" onclick="selectBuildings()">Select Building</button></br>' +
 
 '<button id="autoAssign" style="color:red" onclick="autoSwitch(autoCheck[8], 8, autoName[8], \'autoAssign\')"> Auto Assign </button>' +
@@ -176,124 +176,124 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '<option value="4">Blueprint</option>' +
 '</select></br></br>' +
 
-'<label id="secResLabel"> Secondary Craft % </label>' + 
-'<span id="secResSpan" title="Between 0 and 100"><input id="secResText" type="text" style="width:25px" onchange="secResRatio = this.value" value="30"></span></br></br>' + 
+'<label id="secResLabel"> Secondary Craft % </label>' +
+'<span id="secResSpan" title="Between 0 and 100"><input id="secResText" type="text" style="width:25px" onchange="secResRatio = this.value" value="30"></span></br></br>' +
 
 
-'<button id="autoHunt" style="color:red" onclick="autoSwitch(autoCheck[2], 2, autoName[2], \'autoHunt\')"> Auto Hunt </button></br>' + 
+'<button id="autoHunt" style="color:red" onclick="autoSwitch(autoCheck[2], 2, autoName[2], \'autoHunt\')"> Auto Hunt </button></br>' +
 '<button id="autoTrade" style="color:red" onclick="autoSwitch(autoCheck[3], 3, autoName[3], \'autoTrade\')"> Auto Trade </button></br>' +
 '<button id="autoPraise" style="color:red" onclick="autoSwitch(autoCheck[4], 4, autoName[4], \'autoPraise\')"> Auto Praise </button></br></br>' +
 '<button id="autoScience" style="color:red" onclick="autoSwitch(autoCheck[5], 5, autoName[5], \'autoScience\')"> Auto Science </button></br>' +
 '<button id="autoUpgrade" style="color:red" onclick="autoSwitch(autoCheck[6], 6, autoName[6], \'autoUpgrade\')"> Auto Upgrade </button></br>' +
 '<button id="autoEnergy" style="color:red" onclick="autoSwitch(autoCheck[9], 9, autoName[9], \'autoEnergy\')"> Energy Control </button></br>' +
-'<button id="autoParty" style="color:red" onclick="autoSwitch(autoCheck[7], 7, autoName[7], \'autoParty\')"> Auto Party </button></br></br>' + 
+'<button id="autoParty" style="color:red" onclick="autoSwitch(autoCheck[7], 7, autoName[7], \'autoParty\')"> Auto Party </button></br></br>' +
 '</div>' +
 '</div>'
 
 $("#footerLinks").append(htmlMenuAddition);
 
-var bldSelectAddition = '<div id="buildingSelect" style="display:none; margin-top:-400px; width:200px" class="dialog help">' + 
-'<a href="#" onclick="$(\'#spaceSelect\').toggle(); $(\'#buildingSelect\').hide();" style="position: absolute; top: 10px; left: 15px;">space</a>' + 
-'<a href="#" onclick="$(\'#buildingSelect\').hide();" style="position: absolute; top: 10px; right: 15px;">close</a>' + 
+var bldSelectAddition = '<div id="buildingSelect" style="display:none; margin-top:-400px; width:200px" class="dialog help">' +
+'<a href="#" onclick="$(\'#spaceSelect\').toggle(); $(\'#buildingSelect\').hide();" style="position: absolute; top: 10px; left: 15px;">space</a>' +
+'<a href="#" onclick="$(\'#buildingSelect\').hide();" style="position: absolute; top: 10px; right: 15px;">close</a>' +
 
-'	<br><input type="checkbox" id="hutChecker"><label for="hutChecker" onclick="$(\'.hutCheck\').click();"><b>Kitten Housing</b></label><br>' + 
-'	<input type="checkbox" id="hutBld" class="hutCheck" onchange="verifyBuildingSelected(\'0\', \'hutBld\');"><label for="hutBld">Hut</label><br>' + 
-'	<input type="checkbox" id="houseBld" class="hutCheck" onchange="verifyBuildingSelected(\'1\', \'houseBld\')"><label for="houseBld">Log House</label><br>' + 
-'	<input type="checkbox" id="mansionBld" class="hutCheck" onchange="verifyBuildingSelected(\'2\', \'mansionBld\')"><label for="mansionBld">Mansion</label><br><br>' + 
+'	<br><input type="checkbox" id="hutChecker"><label for="hutChecker" onclick="$(\'.hutCheck\').click();"><b>Kitten Housing</b></label><br>' +
+'	<input type="checkbox" id="hutBld" class="hutCheck" onchange="verifyBuildingSelected(\'0\', \'hutBld\');"><label for="hutBld">Hut</label><br>' +
+'	<input type="checkbox" id="houseBld" class="hutCheck" onchange="verifyBuildingSelected(\'1\', \'houseBld\')"><label for="houseBld">Log House</label><br>' +
+'	<input type="checkbox" id="mansionBld" class="hutCheck" onchange="verifyBuildingSelected(\'2\', \'mansionBld\')"><label for="mansionBld">Mansion</label><br><br>' +
 
-'	<input type="checkbox" id="craftChecker"><label for="craftChecker" onclick="$(\'.craftCheck\').click();"><b>Craft Bonuses</b></label><br>' + 
-'	<input type="checkbox" id="workshopBld" class="craftCheck" onchange="verifyBuildingSelected(\'3\', \'workshopBld\')"><label for="workshopBld">Workshop</label><br>' + 
-'	<input type="checkbox" id="factoryBld" class="craftCheck" onchange="verifyBuildingSelected(\'4\', \'factoryBld\')"><label for="factoryBld">Factory</label><br><br>' + 
+'	<input type="checkbox" id="craftChecker"><label for="craftChecker" onclick="$(\'.craftCheck\').click();"><b>Craft Bonuses</b></label><br>' +
+'	<input type="checkbox" id="workshopBld" class="craftCheck" onchange="verifyBuildingSelected(\'3\', \'workshopBld\')"><label for="workshopBld">Workshop</label><br>' +
+'	<input type="checkbox" id="factoryBld" class="craftCheck" onchange="verifyBuildingSelected(\'4\', \'factoryBld\')"><label for="factoryBld">Factory</label><br><br>' +
 
-'	<input type="checkbox" id="prodChecker"><label for="prodChecker" onclick="$(\'.prodCheck\').click();"><b>Production</b></label><br>' + 
-'	<input type="checkbox" id="fieldBld" class="prodCheck" onchange="verifyBuildingSelected(\'5\', \'fieldBld\')"><label for="fieldBld">Catnip Field</label><br>' + 
-'	<input type="checkbox" id="pastureBld" class="prodCheck" onchange="verifyBuildingSelected(\'6\', \'pastureBld\')"><label for="pastureBld">Pasture/Solar</label><br>' + 
-'	<input type="checkbox" id="mineBld" class="prodCheck" onchange="verifyBuildingSelected(\'7\', \'mineBld\')"><label for="mineBld">Mine</label><br>' + 
-'	<input type="checkbox" id="lumberBld" class="prodCheck" onchange="verifyBuildingSelected(\'8\', \'lumberBld\')"><label for="lumberBld">Lumber Mill</label><br>' + 
-'	<input type="checkbox" id="aqueductBld" class="prodCheck" onchange="verifyBuildingSelected(\'9\', \'aqueductBld\')"><label for="aqueductBld">Aqueduct/Hydro</label><br>' + 
-'	<input type="checkbox" id="oilBld" class="prodCheck" onchange="verifyBuildingSelected(\'10\', \'oilBld\')"><label for="oilBld">Oil Well</label><br>' + 
-'	<input type="checkbox" id="quarryBld" class="prodCheck" onchange="verifyBuildingSelected(\'11\', \'quarryBld\')"><label for="quarryBld">Quarry</label><br><br>' + 
+'	<input type="checkbox" id="prodChecker"><label for="prodChecker" onclick="$(\'.prodCheck\').click();"><b>Production</b></label><br>' +
+'	<input type="checkbox" id="fieldBld" class="prodCheck" onchange="verifyBuildingSelected(\'5\', \'fieldBld\')"><label for="fieldBld">Catnip Field</label><br>' +
+'	<input type="checkbox" id="pastureBld" class="prodCheck" onchange="verifyBuildingSelected(\'6\', \'pastureBld\')"><label for="pastureBld">Pasture/Solar</label><br>' +
+'	<input type="checkbox" id="mineBld" class="prodCheck" onchange="verifyBuildingSelected(\'7\', \'mineBld\')"><label for="mineBld">Mine</label><br>' +
+'	<input type="checkbox" id="lumberBld" class="prodCheck" onchange="verifyBuildingSelected(\'8\', \'lumberBld\')"><label for="lumberBld">Lumber Mill</label><br>' +
+'	<input type="checkbox" id="aqueductBld" class="prodCheck" onchange="verifyBuildingSelected(\'9\', \'aqueductBld\')"><label for="aqueductBld">Aqueduct/Hydro</label><br>' +
+'	<input type="checkbox" id="oilBld" class="prodCheck" onchange="verifyBuildingSelected(\'10\', \'oilBld\')"><label for="oilBld">Oil Well</label><br>' +
+'	<input type="checkbox" id="quarryBld" class="prodCheck" onchange="verifyBuildingSelected(\'11\', \'quarryBld\')"><label for="quarryBld">Quarry</label><br><br>' +
 
-'	<input type="checkbox" id="conversionChecker"><label for="conversionChecker" onclick="$(\'.convertCheck\').click();"><b>Conversion</b></label><br>' + 
-'	<input type="checkbox" id="smelterBld" class="convertCheck" onchange="verifyBuildingSelected(\'12\', \'smelterBld\')"><label for="smelterBld">Smelter</label><br>' + 
-'	<input type="checkbox" id="labBld" class="convertCheck" onchange="verifyBuildingSelected(\'13\', \'labBld\')"><label for="labBld">Bio Lab</label><br>' + 
-'	<input type="checkbox" id="calcinerBld" class="convertCheck" onchange="verifyBuildingSelected(\'14\', \'calcinerBld\')"><label for="calcinerBld">Calciner</label><br>' + 
-'	<input type="checkbox" id="reactorBld" class="convertCheck" onchange="verifyBuildingSelected(\'15\', \'reactorBld\')"><label for="reactorBld">Reactor</label><br>' + 
-'	<input type="checkbox" id="acceleratorBld" class="convertCheck" onchange="verifyBuildingSelected(\'16\', \'acceleratorBld\')"><label for="acceleratorBld">Accelerator</label><br>' + 
-'	<input type="checkbox" id="steamBld" class="convertCheck" onchange="verifyBuildingSelected(\'17\', \'steamBld\')"><label for="steamBld">Steamworks</label><br>' + 
-'	<input type="checkbox" id="magnetoBld" class="convertCheck" onchange="verifyBuildingSelected(\'18\', \'magnetoBld\')"><label for="magnetoBld">Magneto</label><br><br>' + 
+'	<input type="checkbox" id="conversionChecker"><label for="conversionChecker" onclick="$(\'.convertCheck\').click();"><b>Conversion</b></label><br>' +
+'	<input type="checkbox" id="smelterBld" class="convertCheck" onchange="verifyBuildingSelected(\'12\', \'smelterBld\')"><label for="smelterBld">Smelter</label><br>' +
+'	<input type="checkbox" id="labBld" class="convertCheck" onchange="verifyBuildingSelected(\'13\', \'labBld\')"><label for="labBld">Bio Lab</label><br>' +
+'	<input type="checkbox" id="calcinerBld" class="convertCheck" onchange="verifyBuildingSelected(\'14\', \'calcinerBld\')"><label for="calcinerBld">Calciner</label><br>' +
+'	<input type="checkbox" id="reactorBld" class="convertCheck" onchange="verifyBuildingSelected(\'15\', \'reactorBld\')"><label for="reactorBld">Reactor</label><br>' +
+'	<input type="checkbox" id="acceleratorBld" class="convertCheck" onchange="verifyBuildingSelected(\'16\', \'acceleratorBld\')"><label for="acceleratorBld">Accelerator</label><br>' +
+'	<input type="checkbox" id="steamBld" class="convertCheck" onchange="verifyBuildingSelected(\'17\', \'steamBld\')"><label for="steamBld">Steamworks</label><br>' +
+'	<input type="checkbox" id="magnetoBld" class="convertCheck" onchange="verifyBuildingSelected(\'18\', \'magnetoBld\')"><label for="magnetoBld">Magneto</label><br><br>' +
 
-'	<input type="checkbox" id="scienceChecker"><label for="scienceChecker" onclick="$(\'.scienceCheck\').click();"><b>Science</b></label><br>' + 
-'	<input type="checkbox" id="libraryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'19\', \'libraryBld\')"><label for="libraryBld">Library</label><br>' + 
-'	<input type="checkbox" id="academyBld" class="scienceCheck" onchange="verifyBuildingSelected(\'20\', \'academyBld\')"><label for="academyBld">Academy</label><br>' + 
-'	<input type="checkbox" id="obervatoryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'21\', \'obervatoryBld\')"><label for="obervatoryBld">Observatory</label><br><br>' + 
+'	<input type="checkbox" id="scienceChecker"><label for="scienceChecker" onclick="$(\'.scienceCheck\').click();"><b>Science</b></label><br>' +
+'	<input type="checkbox" id="libraryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'19\', \'libraryBld\')"><label for="libraryBld">Library</label><br>' +
+'	<input type="checkbox" id="academyBld" class="scienceCheck" onchange="verifyBuildingSelected(\'20\', \'academyBld\')"><label for="academyBld">Academy</label><br>' +
+'	<input type="checkbox" id="obervatoryBld" class="scienceCheck" onchange="verifyBuildingSelected(\'21\', \'obervatoryBld\')"><label for="obervatoryBld">Observatory</label><br><br>' +
 
-'	<input type="checkbox" id="storageChecker"><label for="storageChecker" onclick="$(\'.storageCheck\').click();"><b>Storage</b></label><br>' + 
-'	<input type="checkbox" id="barnBld" class="storageCheck" onchange="verifyBuildingSelected(\'22\', \'barnBld\')"><label for="barnBld">Barn</label><br>' + 
-'	<input type="checkbox" id="harborBld" class="storageCheck" onchange="verifyBuildingSelected(\'23\', \'harborBld\')"><label for="harborBld">Harbor</label><br>' + 
-'	<input type="checkbox" id="warehouseBld" class="storageCheck" onchange="verifyBuildingSelected(\'24\', \'warehouseBld\')"><label for="warehouseBld">Warehouse</label><br><br>' + 
+'	<input type="checkbox" id="storageChecker"><label for="storageChecker" onclick="$(\'.storageCheck\').click();"><b>Storage</b></label><br>' +
+'	<input type="checkbox" id="barnBld" class="storageCheck" onchange="verifyBuildingSelected(\'22\', \'barnBld\')"><label for="barnBld">Barn</label><br>' +
+'	<input type="checkbox" id="harborBld" class="storageCheck" onchange="verifyBuildingSelected(\'23\', \'harborBld\')"><label for="harborBld">Harbor</label><br>' +
+'	<input type="checkbox" id="warehouseBld" class="storageCheck" onchange="verifyBuildingSelected(\'24\', \'warehouseBld\')"><label for="warehouseBld">Warehouse</label><br><br>' +
 
-'	<input type="checkbox" id="otherChecker"><label for="otherChecker" onclick="$(\'.otherCheck\').click();"><b>Other</b></label><br>' + 
-'	<input type="checkbox" id="ampBld" class="otherCheck" onchange="verifyBuildingSelected(\'25\', \'ampBld\')"><label for="ampBld">Amphitheatre/Broadcast</label><br>' + 
-'	<input type="checkbox" id="tradeBld" class="otherCheck" onchange="verifyBuildingSelected(\'26\', \'tradeBld\')"><label for="tradeBld">Tradepost</label><br>' + 
-'	<input type="checkbox" id="chapelBld" class="otherCheck" onchange="verifyBuildingSelected(\'27\', \'chapelBld\')"><label for="chapelBld">Chapel</label><br>' + 
-'	<input type="checkbox" id="templeBld" class="otherCheck" onchange="verifyBuildingSelected(\'28\', \'templeBld\')"><label for="templeBld">Temple</label><br>' + 
-'	<input type="checkbox" id="mintBld" class="otherCheck" onchange="verifyBuildingSelected(\'29\', \'mintBld\')"><label for="mintBld">Mint</label><br>' + 
-'	<input type="checkbox" id="zigguratBld" class="otherCheck" onchange="verifyBuildingSelected(\'30\', \'zigguratBld\')"><label for="zigguratBld">Ziggurat</label><br>' + 
-'	<input type="checkbox" id="unicBld" class="otherCheck" onchange="verifyBuildingSelected(\'31\', \'unicBld\')"><label for="unicBld">Unicorn Pasture</label><br></br>' + 
+'	<input type="checkbox" id="otherChecker"><label for="otherChecker" onclick="$(\'.otherCheck\').click();"><b>Other</b></label><br>' +
+'	<input type="checkbox" id="ampBld" class="otherCheck" onchange="verifyBuildingSelected(\'25\', \'ampBld\')"><label for="ampBld">Amphitheatre/Broadcast</label><br>' +
+'	<input type="checkbox" id="tradeBld" class="otherCheck" onchange="verifyBuildingSelected(\'26\', \'tradeBld\')"><label for="tradeBld">Tradepost</label><br>' +
+'	<input type="checkbox" id="chapelBld" class="otherCheck" onchange="verifyBuildingSelected(\'27\', \'chapelBld\')"><label for="chapelBld">Chapel</label><br>' +
+'	<input type="checkbox" id="templeBld" class="otherCheck" onchange="verifyBuildingSelected(\'28\', \'templeBld\')"><label for="templeBld">Temple</label><br>' +
+'	<input type="checkbox" id="mintBld" class="otherCheck" onchange="verifyBuildingSelected(\'29\', \'mintBld\')"><label for="mintBld">Mint</label><br>' +
+'	<input type="checkbox" id="zigguratBld" class="otherCheck" onchange="verifyBuildingSelected(\'30\', \'zigguratBld\')"><label for="zigguratBld">Ziggurat</label><br>' +
+'	<input type="checkbox" id="unicBld" class="otherCheck" onchange="verifyBuildingSelected(\'31\', \'unicBld\')"><label for="unicBld">Unicorn Pasture</label><br></br>' +
 
 '</div>'
 
-var spaceSelectAddition = '<div id="spaceSelect" style="display:none; margin-top:-400px; width:200px" class="dialog help">' + 
-'<a href="#" onclick="$(\'#spaceSelect\').hide(); $(\'#buildingSelect\').toggle();" style="position: absolute; top: 10px; left: 15px;">cath</a>' + 
-'<a href="#" onclick="$(\'#spaceSelect\').hide();" style="position: absolute; top: 10px; right: 15px;">close</a>' + 
+var spaceSelectAddition = '<div id="spaceSelect" style="display:none; margin-top:-400px; width:200px" class="dialog help">' +
+'<a href="#" onclick="$(\'#spaceSelect\').hide(); $(\'#buildingSelect\').toggle();" style="position: absolute; top: 10px; left: 15px;">cath</a>' +
+'<a href="#" onclick="$(\'#spaceSelect\').hide();" style="position: absolute; top: 10px; right: 15px;">close</a>' +
 
-'	</br></br><input type="checkbox" id="programs" class="programs" onchange="programBuild = this.checked; console.log(this.checked);"><label for="programs">Programs</label></br></br>' + 
+'	</br></br><input type="checkbox" id="programs" class="programs" onchange="programBuild = this.checked; console.log(this.checked);"><label for="programs">Programs</label></br></br>' +
 
-'	<input type="checkbox" id="spaceChecker"><label for="spaceChecker" onclick="$(\'.spaceCheck\').click();"><b>Space</b></label></br>' + 
+'	<input type="checkbox" id="spaceChecker"><label for="spaceChecker" onclick="$(\'.spaceCheck\').click();"><b>Space</b></label></br>' +
 
-'	<input type="checkbox" id="elevSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'32\', \'elevSBld\');"><label for="elevSBld">Space Elevator</label></br>' + 
-'	<input type="checkbox" id="satSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'33\', \'satSBld\');"><label for="satSBld">Satellite</label></br>' + 
-'	<input type="checkbox" id="statSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'34\', \'statSBld\');"><label for="statSBld">Space Station</label></br></br>' + 
+'	<input type="checkbox" id="elevSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'32\', \'elevSBld\');"><label for="elevSBld">Space Elevator</label></br>' +
+'	<input type="checkbox" id="satSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'33\', \'satSBld\');"><label for="satSBld">Satellite</label></br>' +
+'	<input type="checkbox" id="statSBld" class="spaceCheck" onchange="verifyBuildingSelected(\'34\', \'statSBld\');"><label for="statSBld">Space Station</label></br></br>' +
 
-'	<input type="checkbox" id="moonChecker"><label for="moonChecker" onclick="$(\'.moonCheck\').click();"><b>Moon</b></label></br>' + 
+'	<input type="checkbox" id="moonChecker"><label for="moonChecker" onclick="$(\'.moonCheck\').click();"><b>Moon</b></label></br>' +
 
-'	<input type="checkbox" id="outSBld" class="moonCheck" onchange="verifyBuildingSelected(\'35\', \'outSBld\');"><label for="outSBld">Lunar Outpost</label></br>' + 
-'	<input type="checkbox" id="baseSBld" class="moonCheck" onchange="verifyBuildingSelected(\'36\', \'baseSBld\');"><label for="baseSBld">Moon Base</label></br></br>' + 
+'	<input type="checkbox" id="outSBld" class="moonCheck" onchange="verifyBuildingSelected(\'35\', \'outSBld\');"><label for="outSBld">Lunar Outpost</label></br>' +
+'	<input type="checkbox" id="baseSBld" class="moonCheck" onchange="verifyBuildingSelected(\'36\', \'baseSBld\');"><label for="baseSBld">Moon Base</label></br></br>' +
 
-'	<input type="checkbox" id="duneChecker"><label for="duneChecker" onclick="$(\'.duneCheck\').click();"><b>Dune</b></label></br>' + 
+'	<input type="checkbox" id="duneChecker"><label for="duneChecker" onclick="$(\'.duneCheck\').click();"><b>Dune</b></label></br>' +
 
 
-'	<input type="checkbox" id="crackSBld" class="duneCheck" onchange="verifyBuildingSelected(\'37\', \'crackSBld\');"><label for="crackSBld">Planet Cracker</label></br>' + 
-'	<input type="checkbox" id="fracSBld" class="duneCheck" onchange="verifyBuildingSelected(\'38\', \'fracSBld\');"><label for="fracSBld">Hydro Fracturer</label></br>' + 
-'	<input type="checkbox" id="spiceSBld" class="duneCheck" onchange="verifyBuildingSelected(\'39\', \'spiceSBld\');"><label for="spiceSBld">Spice Refinery</label></br></br>' + 
+'	<input type="checkbox" id="crackSBld" class="duneCheck" onchange="verifyBuildingSelected(\'37\', \'crackSBld\');"><label for="crackSBld">Planet Cracker</label></br>' +
+'	<input type="checkbox" id="fracSBld" class="duneCheck" onchange="verifyBuildingSelected(\'38\', \'fracSBld\');"><label for="fracSBld">Hydro Fracturer</label></br>' +
+'	<input type="checkbox" id="spiceSBld" class="duneCheck" onchange="verifyBuildingSelected(\'39\', \'spiceSBld\');"><label for="spiceSBld">Spice Refinery</label></br></br>' +
 
-'	<input type="checkbox" id="piscineChecker"><label for="piscineChecker" onclick="$(\'piscineCheck\').click();"><b>Piscine</b></label></br>' + 
+'	<input type="checkbox" id="piscineChecker"><label for="piscineChecker" onclick="$(\'piscineCheck\').click();"><b>Piscine</b></label></br>' +
 
-'	<input type="checkbox" id="reVeSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'40\', \'reVeSBld\');"><label for="reVeSBld">Research Vessel</label></br>' + 
-'	<input type="checkbox" id="orbSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'41\', \'orbSBld\');"><label for="orbSBld">Orbital Array</label></br></br>' + 
+'	<input type="checkbox" id="reVeSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'40\', \'reVeSBld\');"><label for="reVeSBld">Research Vessel</label></br>' +
+'	<input type="checkbox" id="orbSBld" class="piscineCheck" onchange="verifyBuildingSelected(\'41\', \'orbSBld\');"><label for="orbSBld">Orbital Array</label></br></br>' +
 
-'	<input type="checkbox" id="heliosChecker"><label for="heliosChecker" onclick="$(\'.heliosCheck\').click();"><b>Helios</b></label></br>' + 
+'	<input type="checkbox" id="heliosChecker"><label for="heliosChecker" onclick="$(\'.heliosCheck\').click();"><b>Helios</b></label></br>' +
 
-'	<input type="checkbox" id="sunSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'42\', \'sunSBld\');"><label for="sunSBld">Sunlifter</label></br>' + 
-'	<input type="checkbox" id="contSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'43\', \'contSBld\');"><label for="contSBld">Containment Chamber</label></br></br>' + 
+'	<input type="checkbox" id="sunSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'42\', \'sunSBld\');"><label for="sunSBld">Sunlifter</label></br>' +
+'	<input type="checkbox" id="contSBld" class="heliosCheck" onchange="verifyBuildingSelected(\'43\', \'contSBld\');"><label for="contSBld">Containment Chamber</label></br></br>' +
 
-'	<input type="checkbox" id="terminusChecker"><label for="terminusChecker" onclick="$(\'.terminusCheck\').click();"><b>Terminus</b></label></br>' + 
+'	<input type="checkbox" id="terminusChecker"><label for="terminusChecker" onclick="$(\'.terminusCheck\').click();"><b>Terminus</b></label></br>' +
 
-'	<input type="checkbox" id="crySBld" class="terminusCheck" onchange="verifyBuildingSelected(\'44\', \'crySBld\');"><label for="crySBld">Cryostation</label></br></br>' + 
+'	<input type="checkbox" id="crySBld" class="terminusCheck" onchange="verifyBuildingSelected(\'44\', \'crySBld\');"><label for="crySBld">Cryostation</label></br></br>' +
 
-'	<input type="checkbox" id="kairoChecker"><label for="kairoChecker" onclick="$(\'.kairoCheck\').click();"><b>Kairo</b></label></br>' + 
+'	<input type="checkbox" id="kairoChecker"><label for="kairoChecker" onclick="$(\'.kairoCheck\').click();"><b>Kairo</b></label></br>' +
 
-'	<input type="checkbox" id="beacSBld" class="kairoCheck" onchange="verifyBuildingSelected(\'45\', \'beacSBld\');"><label for="beacSBld">Space Beacon</label></br></br>' + 
+'	<input type="checkbox" id="beacSBld" class="kairoCheck" onchange="verifyBuildingSelected(\'45\', \'beacSBld\');"><label for="beacSBld">Space Beacon</label></br></br>' +
 
-'	<input type="checkbox" id="yarnChecker"><label for="yarnChecker" onclick="$(\'.yarnCheck\').click();"><b>Yarn</b></label></br>' + 
+'	<input type="checkbox" id="yarnChecker"><label for="yarnChecker" onclick="$(\'.yarnCheck\').click();"><b>Yarn</b></label></br>' +
 
-'	<input type="checkbox" id="terrSBld" class="yarnCheck" onchange="verifyBuildingSelected(\'46\', \'terrSBld\');"><label for="terrSBld">Terraforming Station</label></br>' + 
-'	<input type="checkbox" id="hydrSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'47\', \'hydrSBld\');"><label for="hydrSBld">Hydroponics</label></br></br>' + 
+'	<input type="checkbox" id="terrSBld" class="yarnCheck" onchange="verifyBuildingSelected(\'46\', \'terrSBld\');"><label for="terrSBld">Terraforming Station</label></br>' +
+'	<input type="checkbox" id="hydrSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'47\', \'hydrSBld\');"><label for="hydrSBld">Hydroponics</label></br></br>' +
 
-'	<input type="checkbox" id="centaurusChecker"><label for="centaurusChecker" onclick="$(\'.centaurusCheck\').click();"><b>Centaurus System</b></label></br>' + 
+'	<input type="checkbox" id="centaurusChecker"><label for="centaurusChecker" onclick="$(\'.centaurusCheck\').click();"><b>Centaurus System</b></label></br>' +
 
-'	<input type="checkbox" id="tecSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'48\', \'tecSBld\');"><label for="tecSBld">Tectonic</label></br></br>' + 
+'	<input type="checkbox" id="tecSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'48\', \'tecSBld\');"><label for="tecSBld">Tectonic</label></br></br>' +
 
 '</div>'
 
@@ -354,7 +354,7 @@ function clearScript() {
 }
 
 				// Show current kitten efficiency in the in-game log
-function kittenEfficiency() {		
+function kittenEfficiency() {
 	var timePlayed = gamePage.stats.statsCurrent[3].calculate(game);
 	var numberKittens = gamePage.resPool.get('kittens').value;
 	var curEfficiency = (numberKittens - 70) / timePlayed;
@@ -375,12 +375,12 @@ function autoObserve() {
 		var checkObserveBtn = document.getElementById("observeBtn");
 		if (typeof(checkObserveBtn) != 'undefined' && checkObserveBtn != null) {
 			document.getElementById('observeBtn').click();
-				
+
 		} else {
 		}
 
 }
-	
+
 	// Auto praise the sun
 function autoPraise(){
 	if (autoCheck[4] != "false" && gamePage.bld.getBuildingExt('temple').meta.val > 0) {
@@ -389,80 +389,80 @@ function autoPraise(){
 }
 
 		// Build buildings automatically
-function autoBuild() {		
+function autoBuild() {
 if (autoCheck[0] != "false" && gamePage.ui.activeTabId == 'Bonfire') {
-	
+
 	var btn = gamePage.tabs[0].buttons;
-	
+
 	for (var z = 0; z <  32; z++) {
 		if (buildings[z][1] != false) {
 			if (gamePage.bld.getBuildingExt(buildingsList[z]).meta.unlocked) {
 				for (i = 2 ;i < gamePage.tabs[0].buttons.length; i++) {
-					try { 			
+					try {
 						if (btn[i].model.metadata.name == buildingsList[z]) {
 							btn[i].controller.buyItem(btn[i].model, {}, function(result) {
 								if (result) {btn[i].update();}
 								});
-							} 
+							}
 					} catch(err) {
 					console.log(err);
 					}
 				}
-			}	
+			}
 		}
 	}
-	
+
 	if (gamePage.getResourcePerTick('coal') > 0.01 && steamOn < 1) {
 		gamePage.bld.getBuildingExt('steamworks').meta.on = gamePage.bld.getBuildingExt('steamworks').meta.val;
 		steamOn = 1;
 	}
-	
+
 }
-}			
+}
 
 		// Build space stuff automatically
-function autoSpace() {		
-if (autoCheck[0] != "false") {	
-	
-	var origTab = gamePage.ui.activeTabId;	
-		
+function autoSpace() {
+if (autoCheck[0] != "false") {
+
+	var origTab = gamePage.ui.activeTabId;
+
 		// Build space buildings
 	for (var z = 32; z < buildings.length; z++) {
-		if (buildings[z][1] != false) {		
-			
+		if (buildings[z][1] != false) {
+
 		var spBuild = gamePage.tabs[6].planetPanels[buildings[z][2]].children;
-		
-			try { 			
+
+			try {
 				for (i = 0 ;i < spBuild.length; i++) {
 					if (spBuild[i].model.metadata.name == buildingsList[z]) {
-						
+
 						if (gamePage.ui.activeTabId != "Space") {
 							gamePage.ui.activeTabId = 'Space'; gamePage.render(); // Change the tab so that we can build
 						}
-						
+
 						spBuild[i].controller.buyItem(spBuild[i].model, {}, function(result) {
 							if (result) {spBuild[i].update();}
 							});
-					} 
-				}		
+					}
+				}
 			} catch(err) {
 			console.log(err);
 			}
-			
+
 		}
 	}
-	
+
 		// Build space programs
 	if (programBuild != false) {
 		var spcProg = gamePage.tabs[6].GCPanel.children;
 		for (var i = 0; i < spcProg.length; i++) {
 			if (spcProg[i].model.metadata.unlocked && spcProg[i].model.on == 0) {
-				try { 		
-					
+				try {
+
 					if (gamePage.ui.activeTabId != "Space") {
 					gamePage.ui.activeTabId = 'Space'; gamePage.render(); // Change the tab so that we can build
 					}
-					
+
 					spcProg[i].controller.buyItem(spcProg[i].model, {}, function(result) {
 						if (result) {spcProg[i].update();}
 						});
@@ -472,14 +472,14 @@ if (autoCheck[0] != "false") {
 			}
 		}
 	}
-	
+
 	      if (origTab != gamePage.ui.activeTabId) {
         gamePage.ui.activeTabId = origTab; gamePage.render();
 		  }
-	
+
 }
-}			
-	
+}
+
 // Trade automatically
 function autoTrade() {
 	// If the auto-trade button is not selected, abort
@@ -666,12 +666,12 @@ function emergencyTradeFood() {
 
 		// Hunt automatically
 function autoHunt() {
-if (autoCheck[2] != "false") {	
+if (autoCheck[2] != "false") {
 	var catpower = gamePage.resPool.get('manpower');
 		if (catpower.value > (catpower.maxValue - 1)) {
 			gamePage.village.huntAll();
 		}
-}	
+}
 }
 
 		// Craft primary resources automatically
@@ -685,49 +685,49 @@ for (var i = 0; i < resources.length; i++) {
 		gamePage.craft(resources[i][1], (resourcePerCraft / resources[i][2]));
 		}
 	}
-	
+
 		// Craft secondary resources automatically if primary craftable is > secondary craftable
 for (var i = 0; i < secondaryResources.length; i++) {
 	var priRes = gamePage.resPool.get(secondaryResources[i][0]);
 	var secRes = gamePage.resPool.get(secondaryResources[i][1]);
-	var resMath = priRes.value / secondaryResources[i][2];	
-	
+	var resMath = priRes.value / secondaryResources[i][2];
+
 	if (resMath > 1 && secRes.value < (priRes.value * (secResRatio / 100)) && gamePage.workshop.getCraft(secondaryResources[i][1]).unlocked) {
 		gamePage.craft(secondaryResources[i][1], (resMath * (secResRatio / 100)));
 	}
-}	
+}
 
 		//Craft the fur derivatives
 var furDerivatives = ['parchment', 'manuscript', 'compedium', 'blueprint'];
 	for (var i = 0; i < furDerVal; i++) {
-  		if (gamePage.workshop.getCraft(furDerivatives[i]).unlocked) { 
-				gamePage.craftAll(furDerivatives[i]); 
+  		if (gamePage.workshop.getCraft(furDerivatives[i]).unlocked) {
+				gamePage.craftAll(furDerivatives[i]);
 		}
 	}
-}	
+}
 }
 
 		// Auto Research
-function autoResearch() {	
+function autoResearch() {
 if (autoCheck[5] != "false" && gamePage.libraryTab.visible != false) {
 	var origTab = gamePage.ui.activeTabId;
 	gamePage.ui.activeTabId = 'Science'; gamePage.render();
-	  
+
 	var btn = gamePage.tabs[2].buttons;
 
 	 for (var i = 0; i < btn.length; i++) {
 		if (btn[i].model.metadata.unlocked && btn[i].model.metadata.researched != true) {
-			try { 			
+			try {
 				btn[i].controller.buyItem(btn[i].model, {}, function(result) {
 					if (result) {btn[i].update();}
 					});
 			} catch(err) {
 			console.log(err);
 			}
-			
+
 		}
 	}
-	  
+
       if (origTab != gamePage.ui.activeTabId) {
         gamePage.ui.activeTabId = origTab; gamePage.render();
       }
@@ -739,28 +739,28 @@ if (autoCheck[5] != "false" && gamePage.libraryTab.visible != false) {
 		// Auto Workshop upgrade , tab 3
 function autoWorkshop() {
 if (autoCheck[6] != "false" && gamePage.workshopTab.visible != false) {
-	
+
 	var origTab = gamePage.ui.activeTabId;
 	gamePage.ui.activeTabId = 'Workshop'; gamePage.render();
-	  
+
 	var btn = gamePage.tabs[3].buttons;
 
 	 for (var i = 0; i < btn.length; i++) {
 		if (btn[i].model.metadata.unlocked && btn[i].model.metadata.researched != true) {
-			try { 			
+			try {
 				btn[i].controller.buyItem(btn[i].model, {}, function(result) {
 					if (result) {btn[i].update();}
 					});
 			} catch(err) {
 			console.log(err);
 			}
-			
+
 		}
 	}
-	 	  
+
     if (origTab != gamePage.ui.activeTabId) {
     gamePage.ui.activeTabId = origTab; gamePage.render();
-    }	
+    }
 }
 
 }
@@ -771,7 +771,7 @@ function autoParty() {
 		var catpower = gamePage.resPool.get('manpower').value;
 		var culture = gamePage.resPool.get('culture').value;
 		var parchment = gamePage.resPool.get('parchment').value;
-		
+
 		if (catpower > 1500 && culture > 5000 && parchment > 2500) {
 			if (gamePage.prestige.getPerk("carnivals").researched)
 				gamePage.village.holdFestival(1);
@@ -779,7 +779,7 @@ function autoParty() {
 				gamePage.village.holdFestival(1);
 			}
 		}
-	
+
 	}
 }
 
@@ -793,9 +793,9 @@ function autoAssign() {
 		// Control Energy Consumption
 function energyControl() {
 	if (autoCheck[9] != "false") {
-		proVar = gamePage.resPool.energyProd; 
-		conVar = gamePage.resPool.energyCons;		
-		
+		proVar = gamePage.resPool.energyProd;
+		conVar = gamePage.resPool.energyCons;
+
 			if (bldAccelerator.val > bldAccelerator.on && proVar > (conVar + 3)) {
 				bldAccelerator.on++;
 				conVar++;
@@ -826,7 +826,7 @@ function energyControl() {
 			} else if (bldAccelerator.on > 0 && proVar < conVar) {
 				bldAccelerator.on--;
 				conVar--;
-			}		
+			}
 	}
 }
 
@@ -847,7 +847,7 @@ var runAllAutomation = setInterval(function() {
 	autoPraise();
 	autoBuild();
 	emergencyTradeFood();
-	
+
 	if (gamePage.timer.ticksTotal % 3 === 0) {
 		autoObserve();
 		autoCraft();
@@ -855,18 +855,18 @@ var runAllAutomation = setInterval(function() {
 		autoAssign();
 		energyControl();
 	}
-	
+
 	if (gamePage.timer.ticksTotal % 10 === 0) {
 		autoSpace();
 	}
-	
+
 	if (gamePage.timer.ticksTotal % 25 === 0) {
-		
+
 		autoResearch();
 		autoWorkshop();
 		autoParty();
-		autoTrade();		
-		
+		autoTrade();
+
 	}
 
 }, 200);

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -599,8 +599,8 @@ function tradeZebras() {
 		// Determine how much iron those trades might return
 		var expectedIron = tradesToPerform * maxIronPerTrade;
 
-		// Determine how much existing iron must be converted to steel to make room (up to a limit of 'all of it')
-		var ironOverflow = Math.min((ironResource.value + expectedIron) - targetIron, ironResource.value);
+		// Determine how much existing iron must be converted to steel to make room (up to a limit of 'all of it', minimum of 0)
+		var ironOverflow = Math.max(Math.min((ironResource.value + expectedIron) - targetIron, ironResource.value), 0);
 
 		// Craft the necessary quantity of plates, if any, with each crafting consuming 125 units of iron
 		if (ironOverflow > 0) {
@@ -663,7 +663,7 @@ function tradeDragons() {
 
 	// Determine how many trades to perform depending on the current trade mode
 	if (tradeMax.uranium) {
-		// We are in maximize mode, which means we want to trade for as much uranium as possible, converting any excess into steel
+		// We are in maximize mode, which means we want to trade for as much uranium as possible, converting any excess into thorium
 
 		// Calculate the maximum number of trades we can make and fit the results into our target uranium level
 		var maxTradesFit = Math.floor(targetUranium / expectedUraniumPerTrade);
@@ -676,8 +676,8 @@ function tradeDragons() {
 		// Determine how much uranium those trades will return
 		var expectedUranium = tradesToPerform * expectedUraniumPerTrade;
 
-		// Determine how much existing uranium must be converted to steel to make room (up to a limit of 'all of it')
-		var uraniumOverflow = Math.min((uraniumResource.value + expectedUranium) - targetUranium, uraniumResource.value);
+		// Determine how much existing uranium must be converted to steel to make room (up to a limit of 'all of it', minimum of 0)
+		var uraniumOverflow = Math.max(Math.min((uraniumResource.value + expectedUranium) - targetUranium, uraniumResource.value), 0);
 
 		// Craft the necessary quantity of thorium, with each crafting consuming 250 units of uranium
 		gamePage.craft("thorium", uraniumOverflow / 250);
@@ -765,8 +765,8 @@ function tradeSpiders() {
 		// Determine how much coal those trades will return
 		var expectedCoal = tradesToPerform * expectedCoalPerTrade;
 
-		// Determine how much existing coal must be converted to steel to make room (up to a limit of 'all of it')
-		var coalOverflow = Math.min((coalResource.value + expectedCoal) - targetCoal, coalResource.value);
+		// Determine how much existing coal must be converted to steel to make room (up to a limit of 'all of it', minimum of 0)
+		var coalOverflow = Math.max(Math.min((coalResource.value + expectedCoal) - targetCoal, coalResource.value), 0);
 
 		// Craft the necessary quantity of steel, with each crafting consuming 100 units of coal
 		gamePage.craft("steel", coalOverflow / 100);
@@ -854,8 +854,8 @@ function tradeGriffins() {
 		// Determine how much iron those trades will return
 		var expectedIron = tradesToPerform * expectedIronPerTrade;
 
-		// Determine how much existing iron must be converted to steel to make room (up to a limit of 'all of it')
-		var ironOverflow = Math.min((ironResource.value + expectedIron) - targetIron, ironResource.value);
+		// Determine how much existing iron must be converted to steel to make room (up to a limit of 'all of it', minimum of 0)
+		var ironOverflow = Math.max(Math.min((ironResource.value + expectedIron) - targetIron, ironResource.value), 0);
 
 		// Craft the necessary quantity of steel, with each crafting consuming 100 units of iron
 		gamePage.craft("steel", ironOverflow / 100);

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -662,7 +662,7 @@ function tradeDragons() {
 
 
 	// Determine how many trades to perform depending on the current trade mode
-	if (tradeMax.uranium) {
+	if (tradeMax.uranium && gamePage.workshop.getCraft('thorium').unlocked) {
 		// We are in maximize mode, which means we want to trade for as much uranium as possible, converting any excess into thorium
 
 		// Calculate the maximum number of trades we can make and fit the results into our target uranium level
@@ -745,7 +745,7 @@ function tradeSpiders() {
 
 
 	// Determine how many trades to perform depending on the current trade mode
-	if (tradeMax.coal) {
+	if (tradeMax.coal && gamePage.workshop.getCraft('steel').unlocked) {
 		// We are in maximize mode, which means we want to trade for as much coal as possible, converting any excess into steel
 
 		// Determine the maximum amount of coal we can covert to steel right now
@@ -834,7 +834,7 @@ function tradeGriffins() {
 
 
 	// Determine how many trades to perform depending on the current trade mode
-	if (tradeMax.iron) {
+	if (tradeMax.iron && gamePage.workshop.getCraft('steel').unlocked) {
 		// We are in maximize mode, which means we want to trade for as much iron as possible, converting any excess into steel
 
 		// Determine the maximum amount of iron we can covert to steel right now

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -891,9 +891,10 @@ function emergencyTradeFood() {
 		return;
 	}
 
-	// We only want to trade for food if our catnip reserves are dangerously low, defined as either being under 2% full or within 5 ticks of starvation
+	// If we have a clearly positive catnip income, there is no possibility of starvation and so no need to trade
+	// Alternately, if we have a reserve of at least 5 ticks' consumption or 2% of our maximum stockpile, whichever is larger, there is no need to trade yet
 	var catnipPerTick = gamePage.getResourcePerTick('catnip', true);
-	if (catnipResource.value > Math.max(catnipResource.maxValue * 0.02, catnipPerTick * -5)) {
+	if ((catnipPerTick > 1) || (catnipResource.value > Math.max(catnipResource.maxValue * 0.02, catnipPerTick * -5))) {
 		return;
 	}
 

--- a/ScriptKitties.js
+++ b/ScriptKitties.js
@@ -1,10 +1,10 @@
- // These control the button statuses
+// These control the button statuses
 var autoCheck = ['false', 'false', 'false', 'false', 'false', 'false', 'false', 'false', 'false', 'false'];
 var autoName = ['build', 'craft', 'hunt', 'trade', 'praise', 'science', 'upgrade', 'party', 'assign', 'energy'];
 
 var tradeMax = {uranium: false, coal: false};
 
- // These will allow quick selection of the buildings which consume energy
+// These will allow quick selection of the buildings which consume energy
 var bldSmelter = gamePage.bld.buildingsData[15];
 var bldBioLab = gamePage.bld.buildingsData[9];
 var bldOilWell = gamePage.bld.buildingsData[20];
@@ -12,7 +12,7 @@ var bldFactory = gamePage.bld.buildingsData[22];
 var bldCalciner = gamePage.bld.buildingsData[16];
 var bldAccelerator = gamePage.bld.buildingsData[24];
 
- // These are the assorted variables
+// These are the assorted variables
 var proVar = gamePage.resPool.energyProd;
 var conVar = gamePage.resPool.energyCons;
 var tickDownCounter = 1;
@@ -26,126 +26,126 @@ var programBuild = false;
 
 
 var buildings = [
-		["Hut", false],
-		["Log House", false],
-		["Mansion", false],
-		["Workshop", false],
-		["Factory", false],
-		["Catnip field", false],
-		["Pasture", false],
-		["Mine", false],
-		["Lumber Mill", false],
-		["Aqueduct", false],
-		["Oil Well", false],
-		["Quarry", false],
-		["Smelter", false],
-		["Bio Lab", false],
-		["Calciner", false],
-		["Reactor", false],
-		["Accelerator", false],
-		["Steamworks", false],
-		["Magneto", false],
-		["Library", false],
-		["Academy", false],
-		["Observatory", false],
-		["Barn", false],
-		["Harbour", false],
-		["Warehouse", false],
-		["Amphitheatre", false],
-		["Tradepost", false],
-		["Chapel", false],
-		["Temple", false],
-		["Mint", false],
-		["Ziggurat", false],
-		["Unicorn Pasture", false],
-		["Space Elevator", false, 0],
-		["Satellite", false, 0],
-		["Space Station", false, 0],
-		["Moon Outpost", false, 1],
-		["Moon Base", false, 1],
-		["Planet Cracker", false, 2],
-		["Hydro Fracturer", false, 2],
-		["Spice Refinery", false, 2],
-		["Research Vessel", false, 3],
-		["Orbital Array", false, 3],
-		["Sunlifter", false, 4],
-		["Containment Chamber", false, 4],
-		["Cryostation", false, 5],
-		["Space Beacon", false, 6],
-		["Terraforming Station", false, 7],
-		["Hydroponics", false, 7],
-		["Tectonic", false, 8]
-		];
+	["Hut", false],
+	["Log House", false],
+	["Mansion", false],
+	["Workshop", false],
+	["Factory", false],
+	["Catnip field", false],
+	["Pasture", false],
+	["Mine", false],
+	["Lumber Mill", false],
+	["Aqueduct", false],
+	["Oil Well", false],
+	["Quarry", false],
+	["Smelter", false],
+	["Bio Lab", false],
+	["Calciner", false],
+	["Reactor", false],
+	["Accelerator", false],
+	["Steamworks", false],
+	["Magneto", false],
+	["Library", false],
+	["Academy", false],
+	["Observatory", false],
+	["Barn", false],
+	["Harbour", false],
+	["Warehouse", false],
+	["Amphitheatre", false],
+	["Tradepost", false],
+	["Chapel", false],
+	["Temple", false],
+	["Mint", false],
+	["Ziggurat", false],
+	["Unicorn Pasture", false],
+	["Space Elevator", false, 0],
+	["Satellite", false, 0],
+	["Space Station", false, 0],
+	["Moon Outpost", false, 1],
+	["Moon Base", false, 1],
+	["Planet Cracker", false, 2],
+	["Hydro Fracturer", false, 2],
+	["Spice Refinery", false, 2],
+	["Research Vessel", false, 3],
+	["Orbital Array", false, 3],
+	["Sunlifter", false, 4],
+	["Containment Chamber", false, 4],
+	["Cryostation", false, 5],
+	["Space Beacon", false, 6],
+	["Terraforming Station", false, 7],
+	["Hydroponics", false, 7],
+	["Tectonic", false, 8]
+];
 
 var buildingsList = [
-		["hut"],
-		["logHouse"],
-		["mansion"],
-		["workshop"],
-		["factory"],
-		["field"],
-		["pasture"],
-		["mine"],
-		["lumberMill"],
-		["aqueduct"],
-		["oilWell"],
-		["quarry"],
-		["smelter"],
-		["biolab"],
-		["calciner"],
-		["reactor"],
-		["accelerator"],
-		["steamworks"],
-		["magneto"],
-		["library"],
-		["academy"],
-		["observatory"],
-		["barn"],
-		["harbor"],
-		["warehouse"],
-		["amphitheatre"],
-		["tradepost"],
-		["chapel"],
-		["temple"],
-		["mint"],
-		["ziggurat"],
-		["unicornPasture"],
-		["spaceElevator"],
-		["sattelite"],
-		["spaceStation"],
-		["moonOutpost"],
-		["moonBase"],
-		["planetCracker"],
-		["hydrofracturer"],
-		["spiceRefinery"],
-		["researchVessel"],
-		["orbitalArray"],
-		["sunlifter"],
-		["containmentChamber"],
-		["cryostation"],
-		["spaceBeacon"],
-		["terraformingStation"],
-		["hydroponics"],
-		["tectonic"]
-		];
+	["hut"],
+	["logHouse"],
+	["mansion"],
+	["workshop"],
+	["factory"],
+	["field"],
+	["pasture"],
+	["mine"],
+	["lumberMill"],
+	["aqueduct"],
+	["oilWell"],
+	["quarry"],
+	["smelter"],
+	["biolab"],
+	["calciner"],
+	["reactor"],
+	["accelerator"],
+	["steamworks"],
+	["magneto"],
+	["library"],
+	["academy"],
+	["observatory"],
+	["barn"],
+	["harbor"],
+	["warehouse"],
+	["amphitheatre"],
+	["tradepost"],
+	["chapel"],
+	["temple"],
+	["mint"],
+	["ziggurat"],
+	["unicornPasture"],
+	["spaceElevator"],
+	["sattelite"],
+	["spaceStation"],
+	["moonOutpost"],
+	["moonBase"],
+	["planetCracker"],
+	["hydrofracturer"],
+	["spiceRefinery"],
+	["researchVessel"],
+	["orbitalArray"],
+	["sunlifter"],
+	["containmentChamber"],
+	["cryostation"],
+	["spaceBeacon"],
+	["terraformingStation"],
+	["hydroponics"],
+	["tectonic"]
+];
 
 var resources = [
-       		["catnip", "wood", 50],
-            ["wood", "beam", 175],
-        	["minerals", "slab", 250],
-            ["coal", "steel", 100],
-        	["iron", "plate", 125],
-            ["oil", "kerosene", 7500],
-            ["uranium", "thorium", 250],
-			["unobtainium", "eludium", 1000]
-                ];
+	["catnip", "wood", 50],
+	["wood", "beam", 175],
+	["minerals", "slab", 250],
+	["coal", "steel", 100],
+	["iron", "plate", 125],
+	["oil", "kerosene", 7500],
+	["uranium", "thorium", 250],
+	["unobtainium", "eludium", 1000]
+];
 
 var secondaryResources = [
-			["beam", "scaffold", 50],
-            ["steel", "alloy", 75],
-			["steel", "gear", 15],
-			["slab", "concrate", 2500]
-			]
+	["beam", "scaffold", 50],
+	["steel", "alloy", 75],
+	["steel", "gear", 15],
+	["slab", "concrate", 2500]
+];
 
 var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 
@@ -156,6 +156,7 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 
 '<button id="killSwitch" onclick="clearInterval(clearScript()); gamePage.msg(deadScript);">Kill Switch</button> </br>' +
 '<button id="efficiencyButton" onclick="kittenEfficiency()">Check Efficiency</button></br></br>' +
+
 '<button id="autoBuild" style="color:red" onclick="autoSwitch(autoCheck[0], 0, autoName[0], \'autoBuild\');"> Auto Build </button></br>' +
 '<button id="bldSelect" onclick="selectBuildings()">Select Building</button></br>' +
 
@@ -181,7 +182,6 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '<label id="secResLabel"> Secondary Craft % </label>' +
 '<span id="secResSpan" title="Between 0 and 100"><input id="secResText" type="text" style="width:25px" onchange="secResRatio = this.value" value="30"></span></br></br>' +
 
-
 '<button id="autoHunt" style="color:red" onclick="autoSwitch(autoCheck[2], 2, autoName[2], \'autoHunt\')"> Auto Hunt </button></br>' +
 '<button id="autoTrade" style="color:red" onclick="autoSwitch(autoCheck[3], 3, autoName[3], \'autoTrade\')"> Auto Trade </button></br>' +
 '<input id= "tradeMaxUranium" type="checkbox" onclick="tradeMax.uranium = this.checked" /><label for="tradeMaxUranium">Maximize uranium trades</label></br>' +
@@ -192,7 +192,7 @@ var htmlMenuAddition = '<div id="farRightColumn" class="column">' +
 '<button id="autoEnergy" style="color:red" onclick="autoSwitch(autoCheck[9], 9, autoName[9], \'autoEnergy\')"> Energy Control </button></br>' +
 '<button id="autoParty" style="color:red" onclick="autoSwitch(autoCheck[7], 7, autoName[7], \'autoParty\')"> Auto Party </button></br></br>' +
 '</div>' +
-'</div>'
+'</div>';
 
 $("#footerLinks").append(htmlMenuAddition);
 
@@ -246,7 +246,7 @@ var bldSelectAddition = '<div id="buildingSelect" style="display:none; margin-to
 '	<input type="checkbox" id="zigguratBld" class="otherCheck" onchange="verifyBuildingSelected(\'30\', \'zigguratBld\')"><label for="zigguratBld">Ziggurat</label><br>' +
 '	<input type="checkbox" id="unicBld" class="otherCheck" onchange="verifyBuildingSelected(\'31\', \'unicBld\')"><label for="unicBld">Unicorn Pasture</label><br></br>' +
 
-'</div>'
+'</div>';
 
 var spaceSelectAddition = '<div id="spaceSelect" style="display:none; margin-top:-400px; width:200px" class="dialog help">' +
 '<a href="#" onclick="$(\'#spaceSelect\').hide(); $(\'#buildingSelect\').toggle();" style="position: absolute; top: 10px; left: 15px;">cath</a>' +
@@ -299,7 +299,7 @@ var spaceSelectAddition = '<div id="spaceSelect" style="display:none; margin-top
 
 '	<input type="checkbox" id="tecSBld" class="centaurusCheck" onchange="verifyBuildingSelected(\'48\', \'tecSBld\');"><label for="tecSBld">Tectonic</label></br></br>' +
 
-'</div>'
+'</div>';
 
 function verifyBuildingSelected(buildingNumber, buildingCheckID) {
 	var bldIsChecked = document.getElementById(buildingCheckID).checked;
@@ -357,7 +357,7 @@ function clearScript() {
 	htmlMenuAddition = null;
 }
 
-				// Show current kitten efficiency in the in-game log
+// Show current kitten efficiency in the in-game log
 function kittenEfficiency() {
 	var timePlayed = gamePage.stats.statsCurrent[3].calculate(game);
 	var numberKittens = gamePage.resPool.get('kittens').value;
@@ -367,121 +367,115 @@ function kittenEfficiency() {
 
 
 /* These are the functions which are controlled by the runAllAutomation timer */
-/* These are the functions which are controlled by the runAllAutomation timer */
-/* These are the functions which are controlled by the runAllAutomation timer */
-/* These are the functions which are controlled by the runAllAutomation timer */
-/* These are the functions which are controlled by the runAllAutomation timer */
 
-
-		// Auto Observe Astronomical Events
+// Auto Observe Astronomical Events
 function autoObserve() {
-
-		var checkObserveBtn = document.getElementById("observeBtn");
-		if (typeof(checkObserveBtn) != 'undefined' && checkObserveBtn != null) {
-			document.getElementById('observeBtn').click();
-
-		} else {
-		}
-
+	var checkObserveBtn = document.getElementById("observeBtn");
+	if (typeof(checkObserveBtn) != 'undefined' && checkObserveBtn != null) {
+		document.getElementById('observeBtn').click();
+	}
 }
 
-	// Auto praise the sun
+// Auto praise the sun
 function autoPraise(){
 	if (autoCheck[4] != "false" && gamePage.bld.getBuildingExt('temple').meta.val > 0) {
-			gamePage.religion.praise();
+		gamePage.religion.praise();
 	}
 }
 
-		// Build buildings automatically
+// Build buildings automatically
 function autoBuild() {
-if (autoCheck[0] != "false" && gamePage.ui.activeTabId == 'Bonfire') {
+	if (autoCheck[0] != "false" && gamePage.ui.activeTabId == 'Bonfire') {
+		var btn = gamePage.tabs[0].buttons;
 
-	var btn = gamePage.tabs[0].buttons;
-
-	for (var z = 0; z <  32; z++) {
-		if (buildings[z][1] != false) {
-			if (gamePage.bld.getBuildingExt(buildingsList[z]).meta.unlocked) {
-				for (i = 2 ;i < gamePage.tabs[0].buttons.length; i++) {
-					try {
-						if (btn[i].model.metadata.name == buildingsList[z]) {
-							btn[i].controller.buyItem(btn[i].model, {}, function(result) {
-								if (result) {btn[i].update();}
+		for (var z = 0; z <  32; z++) {
+			if (buildings[z][1] != false) {
+				if (gamePage.bld.getBuildingExt(buildingsList[z]).meta.unlocked) {
+					for (i = 2 ;i < gamePage.tabs[0].buttons.length; i++) {
+						try {
+							if (btn[i].model.metadata.name == buildingsList[z]) {
+								btn[i].controller.buyItem(btn[i].model, {}, function(result) {
+									if (result) {
+										btn[i].update();
+									}
 								});
 							}
-					} catch(err) {
-					console.log(err);
+						} catch(err) {
+							console.log(err);
+						}
 					}
 				}
 			}
 		}
-	}
 
-	if (gamePage.getResourcePerTick('coal') > 0.01 && steamOn < 1) {
-		gamePage.bld.getBuildingExt('steamworks').meta.on = gamePage.bld.getBuildingExt('steamworks').meta.val;
-		steamOn = 1;
+		if (gamePage.getResourcePerTick('coal') > 0.01 && steamOn < 1) {
+			gamePage.bld.getBuildingExt('steamworks').meta.on = gamePage.bld.getBuildingExt('steamworks').meta.val;
+			steamOn = 1;
+		}
 	}
-
-}
 }
 
-		// Build space stuff automatically
+// Build space stuff automatically
 function autoSpace() {
-if (autoCheck[0] != "false") {
-
-	var origTab = gamePage.ui.activeTabId;
+	if (autoCheck[0] != "false") {
+		var origTab = gamePage.ui.activeTabId;
 
 		// Build space buildings
-	for (var z = 32; z < buildings.length; z++) {
-		if (buildings[z][1] != false) {
+		for (var z = 32; z < buildings.length; z++) {
+			if (buildings[z][1] != false) {
+				var spBuild = gamePage.tabs[6].planetPanels[buildings[z][2]].children;
 
-		var spBuild = gamePage.tabs[6].planetPanels[buildings[z][2]].children;
+				try {
+					for (i = 0; i < spBuild.length; i++) {
+						if (spBuild[i].model.metadata.name == buildingsList[z]) {
+							// Change the tab so that we can build
+							if (gamePage.ui.activeTabId != "Space") {
+								gamePage.ui.activeTabId = 'Space';
+								gamePage.render();
+							}
 
-			try {
-				for (i = 0 ;i < spBuild.length; i++) {
-					if (spBuild[i].model.metadata.name == buildingsList[z]) {
-
-						if (gamePage.ui.activeTabId != "Space") {
-							gamePage.ui.activeTabId = 'Space'; gamePage.render(); // Change the tab so that we can build
-						}
-
-						spBuild[i].controller.buyItem(spBuild[i].model, {}, function(result) {
-							if (result) {spBuild[i].update();}
+							spBuild[i].controller.buyItem(spBuild[i].model, {}, function(result) {
+								if (result) {
+									spBuild[i].update();
+								}
 							});
+						}
 					}
+				} catch(err) {
+					console.log(err);
 				}
-			} catch(err) {
-			console.log(err);
 			}
-
 		}
-	}
 
 		// Build space programs
-	if (programBuild != false) {
-		var spcProg = gamePage.tabs[6].GCPanel.children;
-		for (var i = 0; i < spcProg.length; i++) {
-			if (spcProg[i].model.metadata.unlocked && spcProg[i].model.on == 0) {
-				try {
+		if (programBuild != false) {
+			var spcProg = gamePage.tabs[6].GCPanel.children;
+			for (var i = 0; i < spcProg.length; i++) {
+				if (spcProg[i].model.metadata.unlocked && spcProg[i].model.on == 0) {
+					try {
+						// Change the tab so that we can build
+						if (gamePage.ui.activeTabId != "Space") {
+							gamePage.ui.activeTabId = 'Space';
+							gamePage.render();
+						}
 
-					if (gamePage.ui.activeTabId != "Space") {
-					gamePage.ui.activeTabId = 'Space'; gamePage.render(); // Change the tab so that we can build
-					}
-
-					spcProg[i].controller.buyItem(spcProg[i].model, {}, function(result) {
-						if (result) {spcProg[i].update();}
+						spcProg[i].controller.buyItem(spcProg[i].model, {}, function(result) {
+							if (result) {
+								spcProg[i].update();
+							}
 						});
-				} catch(err) {
-				console.log(err);
+					} catch(err) {
+						console.log(err);
+					}
 				}
 			}
 		}
+
+		if (origTab != gamePage.ui.activeTabId) {
+			gamePage.ui.activeTabId = origTab;
+			gamePage.render();
+		}
 	}
-
-	      if (origTab != gamePage.ui.activeTabId) {
-        gamePage.ui.activeTabId = origTab; gamePage.render();
-		  }
-
-}
 }
 
 // Trade automatically
@@ -511,6 +505,7 @@ function autoTrade() {
 	tradeDragons();
 	tradeSpiders();
 }
+
 
 // Trade with the Zebras
 var titaniumResource = gamePage.resPool.get('titanium');
@@ -859,108 +854,108 @@ function emergencyTradeFood() {
 }
 
 
-		// Hunt automatically
+// Hunt automatically
 function autoHunt() {
-if (autoCheck[2] != "false") {
-	var catpower = gamePage.resPool.get('manpower');
+	if (autoCheck[2] != "false") {
+		var catpower = gamePage.resPool.get('manpower');
 		if (catpower.value > (catpower.maxValue - 1)) {
 			gamePage.village.huntAll();
 		}
-}
+	}
 }
 
-		// Craft primary resources automatically
+// Craft primary resources automatically
 function autoCraft() {
-if (autoCheck[1] != "false") {
-for (var i = 0; i < resources.length; i++) {
-    var curRes = gamePage.resPool.get(resources[i][0]);
-    var resourcePerTick = gamePage.getResourcePerTick(resources[i][0], true);
-    var resourcePerCraft = (resourcePerTick * 3);
-		if (curRes.value > (curRes.maxValue - resourcePerCraft) && gamePage.workshop.getCraft(resources[i][1]).unlocked) {
-		gamePage.craft(resources[i][1], (resourcePerCraft / resources[i][2]));
+	if (autoCheck[1] != "false") {
+		for (var i = 0; i < resources.length; i++) {
+			var curRes = gamePage.resPool.get(resources[i][0]);
+			var resourcePerTick = gamePage.getResourcePerTick(resources[i][0], true);
+			var resourcePerCraft = (resourcePerTick * 3);
+			if (curRes.value > (curRes.maxValue - resourcePerCraft) && gamePage.workshop.getCraft(resources[i][1]).unlocked) {
+				gamePage.craft(resources[i][1], (resourcePerCraft / resources[i][2]));
+			}
 		}
-	}
 
 		// Craft secondary resources automatically if primary craftable is > secondary craftable
-for (var i = 0; i < secondaryResources.length; i++) {
-	var priRes = gamePage.resPool.get(secondaryResources[i][0]);
-	var secRes = gamePage.resPool.get(secondaryResources[i][1]);
-	var resMath = priRes.value / secondaryResources[i][2];
+		for (var i = 0; i < secondaryResources.length; i++) {
+			var priRes = gamePage.resPool.get(secondaryResources[i][0]);
+			var secRes = gamePage.resPool.get(secondaryResources[i][1]);
+			var resMath = priRes.value / secondaryResources[i][2];
 
-	if (resMath > 1 && secRes.value < (priRes.value * (secResRatio / 100)) && gamePage.workshop.getCraft(secondaryResources[i][1]).unlocked) {
-		gamePage.craft(secondaryResources[i][1], (resMath * (secResRatio / 100)));
-	}
-}
+			if (resMath > 1 && secRes.value < (priRes.value * (secResRatio / 100)) && gamePage.workshop.getCraft(secondaryResources[i][1]).unlocked) {
+				gamePage.craft(secondaryResources[i][1], (resMath * (secResRatio / 100)));
+			}
+		}
 
 		//Craft the fur derivatives
-var furDerivatives = ['parchment', 'manuscript', 'compedium', 'blueprint'];
-	for (var i = 0; i < furDerVal; i++) {
-  		if (gamePage.workshop.getCraft(furDerivatives[i]).unlocked) {
+		var furDerivatives = ['parchment', 'manuscript', 'compedium', 'blueprint'];
+		for (var i = 0; i < furDerVal; i++) {
+			if (gamePage.workshop.getCraft(furDerivatives[i]).unlocked) {
 				gamePage.craftAll(furDerivatives[i]);
+			}
 		}
 	}
 }
-}
 
-		// Auto Research
+// Auto Research
 function autoResearch() {
-if (autoCheck[5] != "false" && gamePage.libraryTab.visible != false) {
-	var origTab = gamePage.ui.activeTabId;
-	gamePage.ui.activeTabId = 'Science'; gamePage.render();
+	if (autoCheck[5] != "false" && gamePage.libraryTab.visible != false) {
+		var origTab = gamePage.ui.activeTabId;
+		gamePage.ui.activeTabId = 'Science';
+		gamePage.render();
 
-	var btn = gamePage.tabs[2].buttons;
+		var btn = gamePage.tabs[2].buttons;
 
-	 for (var i = 0; i < btn.length; i++) {
-		if (btn[i].model.metadata.unlocked && btn[i].model.metadata.researched != true) {
-			try {
-				btn[i].controller.buyItem(btn[i].model, {}, function(result) {
-					if (result) {btn[i].update();}
+		for (var i = 0; i < btn.length; i++) {
+			if (btn[i].model.metadata.unlocked && btn[i].model.metadata.researched != true) {
+				try {
+					btn[i].controller.buyItem(btn[i].model, {}, function(result) {
+						if (result) {
+							btn[i].update();
+						}
 					});
-			} catch(err) {
-			console.log(err);
+				} catch(err) {
+					console.log(err);
+				}
 			}
+		}
 
+		if (origTab != gamePage.ui.activeTabId) {
+			gamePage.ui.activeTabId = origTab; gamePage.render();
 		}
 	}
-
-      if (origTab != gamePage.ui.activeTabId) {
-        gamePage.ui.activeTabId = origTab; gamePage.render();
-      }
 }
 
-
-}
-
-		// Auto Workshop upgrade , tab 3
+// Auto Workshop upgrade , tab 3
 function autoWorkshop() {
-if (autoCheck[6] != "false" && gamePage.workshopTab.visible != false) {
+	if (autoCheck[6] != "false" && gamePage.workshopTab.visible != false) {
+		var origTab = gamePage.ui.activeTabId;
+		gamePage.ui.activeTabId = 'Workshop';
+		gamePage.render();
 
-	var origTab = gamePage.ui.activeTabId;
-	gamePage.ui.activeTabId = 'Workshop'; gamePage.render();
+		var btn = gamePage.tabs[3].buttons;
 
-	var btn = gamePage.tabs[3].buttons;
-
-	 for (var i = 0; i < btn.length; i++) {
-		if (btn[i].model.metadata.unlocked && btn[i].model.metadata.researched != true) {
-			try {
-				btn[i].controller.buyItem(btn[i].model, {}, function(result) {
-					if (result) {btn[i].update();}
+		for (var i = 0; i < btn.length; i++) {
+			if (btn[i].model.metadata.unlocked && btn[i].model.metadata.researched != true) {
+				try {
+					btn[i].controller.buyItem(btn[i].model, {}, function(result) {
+						if (result) {
+							btn[i].update();
+						}
 					});
-			} catch(err) {
-			console.log(err);
+				} catch(err) {
+					console.log(err);
+				}
 			}
+		}
 
+		if (origTab != gamePage.ui.activeTabId) {
+			gamePage.ui.activeTabId = origTab; gamePage.render();
 		}
 	}
-
-    if (origTab != gamePage.ui.activeTabId) {
-    gamePage.ui.activeTabId = origTab; gamePage.render();
-    }
 }
 
-}
-
-		// Festival automatically
+// Festival automatically
 function autoParty() {
 	if (autoCheck[7] != "false" && gamePage.science.get("drama").researched) {
 		var catpower = gamePage.resPool.get('manpower').value;
@@ -978,50 +973,50 @@ function autoParty() {
 	}
 }
 
-		// Auto assign new kittens to selected job
+// Auto assign new kittens to selected job
 function autoAssign() {
 	if (autoCheck[8] != "false" && gamePage.village.getJob(autoChoice).unlocked) {
 		gamePage.village.assignJob(gamePage.village.getJob(autoChoice));
 	}
 }
 
-		// Control Energy Consumption
+// Control Energy Consumption
 function energyControl() {
 	if (autoCheck[9] != "false") {
 		proVar = gamePage.resPool.energyProd;
 		conVar = gamePage.resPool.energyCons;
 
-			if (bldAccelerator.val > bldAccelerator.on && proVar > (conVar + 3)) {
-				bldAccelerator.on++;
-				conVar++;
-			} else if (bldCalciner.val > bldCalciner.on && proVar > (conVar + 3)) {
-				bldCalciner.on++;
-				conVar++;
-			} else if (bldFactory.val > bldFactory.on && proVar > (conVar + 3)) {
-				bldFactory.on++;
-				conVar++;
-			} else if (bldOilWell.val > bldOilWell.on && proVar > (conVar + 3)) {
-				bldOilWell.on++;
-				conVar++;
-			} else if (bldBioLab.val > bldBioLab.on && proVar > (conVar + 3)) {
-				bldBioLab.on++;
-				conVar++;
-			} else if (bldBioLab.on > 0 && proVar < conVar) {
-				bldBioLab.on--;
-				conVar--;
-			} else if (bldOilWell.on > 0 && proVar < conVar) {
-				bldOilWell.on--;
-				conVar--;
-			} else if (bldFactory.on > 0 && proVar < conVar) {
-				bldFactory.on--;
-				conVar--;
-			} else if (bldCalciner.on > 0 && proVar < conVar) {
-				bldCalciner.on--;
-				conVar--;
-			} else if (bldAccelerator.on > 0 && proVar < conVar) {
-				bldAccelerator.on--;
-				conVar--;
-			}
+		if (bldAccelerator.val > bldAccelerator.on && proVar > (conVar + 3)) {
+			bldAccelerator.on++;
+			conVar++;
+		} else if (bldCalciner.val > bldCalciner.on && proVar > (conVar + 3)) {
+			bldCalciner.on++;
+			conVar++;
+		} else if (bldFactory.val > bldFactory.on && proVar > (conVar + 3)) {
+			bldFactory.on++;
+			conVar++;
+		} else if (bldOilWell.val > bldOilWell.on && proVar > (conVar + 3)) {
+			bldOilWell.on++;
+			conVar++;
+		} else if (bldBioLab.val > bldBioLab.on && proVar > (conVar + 3)) {
+			bldBioLab.on++;
+			conVar++;
+		} else if (bldBioLab.on > 0 && proVar < conVar) {
+			bldBioLab.on--;
+			conVar--;
+		} else if (bldOilWell.on > 0 && proVar < conVar) {
+			bldOilWell.on--;
+			conVar--;
+		} else if (bldFactory.on > 0 && proVar < conVar) {
+			bldFactory.on--;
+			conVar--;
+		} else if (bldCalciner.on > 0 && proVar < conVar) {
+			bldCalciner.on--;
+			conVar--;
+		} else if (bldAccelerator.on > 0 && proVar < conVar) {
+			bldAccelerator.on--;
+			conVar--;
+		}
 	}
 }
 
@@ -1034,10 +1029,9 @@ function autoNip() {
 	}
 }
 
-		// This function keeps track of the game's ticks and uses math to execute these functions at set times relative to the game.
+// This function keeps track of the game's ticks and uses math to execute these functions at set times relative to the game.
 clearInterval(runAllAutomation);
 var runAllAutomation = setInterval(function() {
-
 	autoNip();
 	autoPraise();
 	autoBuild();
@@ -1056,12 +1050,10 @@ var runAllAutomation = setInterval(function() {
 	}
 
 	if (gamePage.timer.ticksTotal % 25 === 0) {
-
 		autoResearch();
 		autoWorkshop();
 		autoParty();
 		autoTrade();
-
 	}
 
 }, 200);


### PR DESCRIPTION
- New version will now always trade with Leviathans if possible; old version only traded with them if gold was near cap
- New version will only trade with Zebras and Dragons is gold is within 26 ticks' production of cap; old version would trade if within 200 ticks
- New version will trade with Zebras and Dragons if the critical resource (titanium and uranium, respectively) is more than 25 ticks' production below cap; old version would trade with Zebras if titanium was below 90% and with Dragons unconditionally
- New version estimates how many trades are necessary to fill the critical resource and limit itself to executing that many trades with Zebras and Dragons (with the Leviathans, it always executes the maximum possible number of trades); old version would always trade the maximum, even if that cause massive waste
- New version, when trading with Zebras, calculates how much iron the trade could potentially return, and crafts iron into plates as necessary to ensure there's enough room in the iron stockpile to fit it all; old version did not do this, causing it to frequently waste the iron
- New version can trade with multiple partners in a single cycle; old version would only ever trade with one partner per call